### PR TITLE
feat: add job CRUD, and improve UX

### DIFF
--- a/src/app/api/jobs/[jobId]/route.ts
+++ b/src/app/api/jobs/[jobId]/route.ts
@@ -22,6 +22,23 @@ const appStatusToPrisma: Record<string, string> = {
   [JobStatus.CLOSED]: "closed",
 };
 
+const statusTimelineEvent: Record<string, string> = {
+  saved: "Jobbet sparat",
+  applied: "Ansökan skickad",
+  in_process: "Pågår",
+  interview: "Intervju",
+  offer: "Erbjudande mottaget",
+  closed: "Avslutad",
+};
+
+function formatSwedishDate(date: Date): string {
+  return new Intl.DateTimeFormat("sv-SE", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(date);
+}
+
 export async function GET(
   _request: NextRequest,
   context: { params: Promise<{ jobId: string }> },
@@ -54,7 +71,14 @@ export async function GET(
     notes: job.notes,
     status: prismaStatusToAppStatus[job.status] ?? JobStatus.SAVED,
     contactPerson: job.contactPerson ?? { name: "", role: "", email: "", phone: "" },
-    timeline: job.timeline.map((t) => ({ date: t.date, event: t.event })),
+    timeline: job.timeline
+      .map((t) => ({ date: t.date, event: t.event }))
+      .sort((a, b) => {
+        const isDeadline = (e: string) => e.toLowerCase().includes("sista");
+        if (isDeadline(a.event)) return 1;
+        if (isDeadline(b.event)) return -1;
+        return 0;
+      }),
   } satisfies Job);
 }
 
@@ -77,6 +101,9 @@ export async function PATCH(
     return NextResponse.json({ error: "Jobbet kunde inte hittas." }, { status: 404 });
   }
 
+  const nextPrismaStatus = updates.status !== undefined ? appStatusToPrisma[updates.status] : undefined;
+  const statusChanged = nextPrismaStatus !== undefined && nextPrismaStatus !== existing.status;
+
   const job = await prisma.job.update({
     where: { id: jobId },
     data: {
@@ -87,7 +114,7 @@ export async function PATCH(
       ...(updates.workload !== undefined && { workload: updates.workload }),
       ...(updates.jobUrl !== undefined && { jobUrl: updates.jobUrl }),
       ...(updates.notes !== undefined && { notes: updates.notes }),
-      ...(updates.status !== undefined && { status: appStatusToPrisma[updates.status] as never }),
+      ...(nextPrismaStatus !== undefined && { status: nextPrismaStatus as never }),
       ...(updates.contactPerson !== undefined && {
         contactPerson: {
           upsert: {
@@ -96,12 +123,16 @@ export async function PATCH(
           },
         },
       }),
-      ...(updates.timeline !== undefined && {
-        timeline: {
-          deleteMany: {},
-          create: updates.timeline,
-        },
-      }),
+      ...(updates.timeline !== undefined
+        ? { timeline: { deleteMany: {}, create: updates.timeline } }
+        : statusChanged && {
+            timeline: {
+              create: {
+                date: formatSwedishDate(new Date()),
+                event: statusTimelineEvent[nextPrismaStatus],
+              },
+            },
+          }),
     },
     include: { contactPerson: true, timeline: true },
   });

--- a/src/app/jobb/[jobId]/page.tsx
+++ b/src/app/jobb/[jobId]/page.tsx
@@ -4,6 +4,7 @@ import { deleteJob, getJob } from "@/app/services/services";
 import type { Job } from "@/app/types";
 import { Btn } from "@/components/ui/btn";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Loader } from "@/components/ui/loader";
 import { StatusSelect } from "@/components/ui/status-select";
 import { ExternalLink, Trash2 } from "lucide-react";
 import Link from "next/link";
@@ -66,11 +67,9 @@ export default function JobDetailPage({
 
   if (!job && !error) {
     return (
-      <main className="min-h-svh pt-4">
-        <section className="flex w-full max-w-3xl flex-col gap-4 p-5 sm:p-8 md:max-w-none">
-          <h1 className="font-display text-4xl md:text-[2.4rem]">Jobbdetaljer</h1>
-          <p className="text-base text-app-muted sm:text-lg">Laddar jobb...</p>
-        </section>
+      <main className="flex min-h-svh flex-col items-center justify-center gap-3">
+        <Loader size={40} />
+        <p className="text-sm text-app-muted">Laddar jobbdetaljer...</p>
       </main>
     );
   }
@@ -130,8 +129,8 @@ export default function JobDetailPage({
             <div className="relative mt-2">
               <div aria-hidden="true" className="absolute top-1 bottom-2 left-1.25 w-px bg-app-stroke" />
               <ul className="space-y-4">
-                {job.timeline.map((item) => (
-                  <li key={item.date} className="relative flex gap-3 items-center">
+                {job.timeline.map((item, index) => (
+                  <li key={`${job.title}-${item.date}-${index}`} className="relative flex gap-3 items-center">
                     <span className="mt-1 h-3 w-3 shrink-0 rounded-full bg-app-primary-strong ring-3 ring-app-card" />
                     <div>
                     <strong className="block text-md text-app-muted">{item.date}</strong>


### PR DESCRIPTION
- Add full CRUD for jobs: POST, PATCH, DELETE all use Prisma
 - Status updates automatically append a dated timeline entry in Swedish
 - Timeline always sorts deadline ("Sista ansökningsdag") last
 - Add /jobb listing page with delete button per job
 - Replace browser confirm() with custom ConfirmDialog on both listing and detail pages
 - Add Loader animation to job detail loading state
 - Wire dashboard, report, and konto pages to real data via API endpoints