### PR TITLE
update: upsert user profile and pre-fill form on create-profile page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "applytrack",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@clerk/nextjs": "^7.0.6",

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -106,8 +106,20 @@ export async function POST(
     );
   }
 
-  const userData = await prisma.user.create({
-    data: {
+  const select = {
+    complete: true,
+    email: true,
+    id: true,
+    name: true,
+    profession: true,
+    role: true,
+    termsAcceptedAt: true,
+    termsVersion: true,
+  } as const;
+
+  const userData = await prisma.user.upsert({
+    where: { email },
+    create: {
       id: clerkUser.id,
       email,
       name,
@@ -116,16 +128,14 @@ export async function POST(
       termsAcceptedAt: new Date(),
       termsVersion: TERMS_VERSION,
     },
-    select: {
+    update: {
+      name,
+      profession,
       complete: true,
-      email: true,
-      id: true,
-      name: true,
-      profession: true,
-      role: true,
-      termsAcceptedAt: true,
-      termsVersion: true,
+      termsAcceptedAt: new Date(),
+      termsVersion: TERMS_VERSION,
     },
+    select,
   });
 
   return NextResponse.json(userData as User, { status: 201 });

--- a/src/app/konto/create-profile/page.tsx
+++ b/src/app/konto/create-profile/page.tsx
@@ -6,11 +6,17 @@ import { TERMS_VERSION } from "@/lib/legal";
 import { useUser } from "@clerk/nextjs";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type FormState = {
   name: string;
   profession: string;
+};
+
+type ExistingProfile = {
+  name: string;
+  profession: string;
+  termsVersion: string | null;
 };
 
 export default function CreateProfilePage() {
@@ -23,6 +29,31 @@ export default function CreateProfilePage() {
   const [termsAccepted, setTermsAccepted] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [feedback, setFeedback] = useState("");
+  const [existingProfile, setExistingProfile] =
+    useState<ExistingProfile | null>(null);
+  const [isLoadingProfile, setIsLoadingProfile] = useState(true);
+
+  useEffect(() => {
+    async function fetchProfile() {
+      try {
+        const res = await fetch("/api/user");
+        if (res.ok) {
+          const data = (await res.json()) as ExistingProfile;
+          setExistingProfile(data);
+          setForm({ name: data.name, profession: data.profession });
+        }
+      } catch {
+        // No existing profile, proceed with empty form
+      } finally {
+        setIsLoadingProfile(false);
+      }
+    }
+    void fetchProfile();
+  }, []);
+
+  const needsTermsUpdate =
+    existingProfile !== null &&
+    existingProfile.termsVersion !== TERMS_VERSION;
 
   function updateField<K extends keyof FormState>(field: K, value: FormState[K]) {
     setForm((prev) => ({ ...prev, [field]: value }));
@@ -46,14 +77,14 @@ export default function CreateProfilePage() {
 
       if (!res.ok) {
         const data = (await res.json()) as { error?: string };
-        setFeedback(data.error ?? "Kunde inte skapa profilen just nu.");
+        setFeedback(data.error ?? "Kunde inte spara profilen.");
         return;
       }
 
       router.push("/");
       router.refresh();
     } catch {
-      setFeedback("Kunde inte skapa profilen just nu.");
+      setFeedback("Kunde inte spara profilen.");
     } finally {
       setIsSubmitting(false);
     }
@@ -64,6 +95,16 @@ export default function CreateProfilePage() {
     void submitProfile();
   };
 
+  if (isLoadingProfile) {
+    return (
+      <main className="min-h-dvh px-4 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
+        <h1 className="font-display text-4xl leading-none">
+          Jobi<span className="text-app-primary">.sh</span>
+        </h1>
+      </main>
+    );
+  }
+
   return (
     <main className="min-h-dvh px-4 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
       <h1 className="font-display text-4xl leading-none">
@@ -72,16 +113,35 @@ export default function CreateProfilePage() {
       <section className="mx-auto flex min-h-dvh w-full max-w-2xl flex-col gap-4">
         <div className="flex flex-1 flex-col items-center justify-center gap-4">
           <div className="w-full text-center">
-            <h2 className="text-2xl">Skapa profil</h2>
-            <p className="mt-2 text-base text-app-muted">
-              Fyll i dina uppgifter för att komma igång.
-            </p>
+            {needsTermsUpdate ? (
+              <>
+                <h2 className="text-2xl">Uppdaterade användarvillkor</h2>
+                <p className="mt-2 text-base text-app-muted">
+                  Vi har uppdaterat våra användarvillkor. Du behöver godkänna
+                  dem för att fortsätta använda Jobi.sh.
+                </p>
+              </>
+            ) : (
+              <>
+                <h2 className="text-2xl">Skapa profil</h2>
+                <p className="mt-2 text-base text-app-muted">
+                  Fyll i dina uppgifter för att komma igång.
+                </p>
+              </>
+            )}
             {feedback ? (
               <p className="mt-4 rounded-2xl border border-app-stroke bg-app-card px-4 py-3 text-sm text-red-500">
                 {feedback}
               </p>
             ) : null}
           </div>
+
+          {needsTermsUpdate && (
+            <div className="w-full rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              Dina uppgifter är ifyllda nedan. Granska dem och godkänn de
+              uppdaterade villkoren för att fortsätta.
+            </div>
+          )}
 
           <form className="flex w-full flex-col gap-4" onSubmit={handleSubmit}>
             <label className="block font-semibold text-app-muted">
@@ -144,7 +204,11 @@ export default function CreateProfilePage() {
             </label>
 
             <Btn className="w-full" disabled={isSubmitting} type="submit">
-              {isSubmitting ? "Skapar profil..." : "Skapa profil"}
+              {isSubmitting
+                ? "Sparar..."
+                : needsTermsUpdate
+                  ? "Godkänn och fortsätt"
+                  : "Skapa profil"}
             </Btn>
           </form>
         </div>


### PR DESCRIPTION
- Replace prisma.user.create with upsert so submitting when a profile already exists updates it instead of throwing a 500
- Remove separate PATCH handler — POST now handles both create and update
- Fetch existing profile on mount to pre-fill name/profession fields
- Show updated terms notice and adjusted button/heading when user has an existing profile with an outdated terms version