### PR TITLE
Feature/tanstack query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@clerk/nextjs": "^7.0.6",
         "@prisma/adapter-pg": "^7.5.0",
         "@prisma/client": "^7.5.0",
+        "@tanstack/react-query": "^5.95.2",
         "apexcharts": "^5.10.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -3496,6 +3497,32 @@
       "version": "5.90.16",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
       "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.95.2.tgz",
+      "integrity": "sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.95.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query/node_modules/@tanstack/query-core": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.95.2.tgz",
+      "integrity": "sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@clerk/nextjs": "^7.0.6",
     "@prisma/adapter-pg": "^7.5.0",
     "@prisma/client": "^7.5.0",
+    "@tanstack/react-query": "^5.95.2",
     "apexcharts": "^5.10.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/jobb/[jobId]/page.tsx
+++ b/src/app/jobb/[jobId]/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { deleteJob, getJob } from "@/app/services/services";
 import type { Job } from "@/app/types";
 import { Btn } from "@/components/ui/btn";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Loader } from "@/components/ui/loader";
 import { StatusSelect } from "@/components/ui/status-select";
 import { ExternalLink, PencilLine, Trash2 } from "lucide-react";
+import { useDeleteJob, useJob } from "@/lib/hooks/jobs";
+import { ExternalLink, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { use, useEffect, useState } from "react";
+import { use, useState } from "react";
 import { toast } from "sonner";
 
 export default function JobDetailPage({
@@ -19,53 +20,25 @@ export default function JobDetailPage({
 }>) {
   const { jobId } = use(params);
   const router = useRouter();
-  const [job, setJob] = useState<Job | null>(null);
-  const [error, setError] = useState("");
-  const [isDeleting, setIsDeleting] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
-  useEffect(() => {
-    let isMounted = true;
+  const { data: job, isLoading, isError } = useJob(jobId);
+  const deleteJobMutation = useDeleteJob();
 
-    async function loadJob() {
-      try {
-        const nextJob = await getJob(jobId);
-
-        if (isMounted) {
-          setJob(nextJob);
-          setError("");
-        }
-      } catch {
-        if (isMounted) {
-          setJob(null);
-          setError("Jobbet kunde inte hittas.");
-        }
-      }
-    }
-
-    void loadJob();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [jobId]);
-
-  async function handleDelete() {
-    setIsDeleting(true);
-
-    try {
-      await deleteJob(jobId);
-      toast.success("Jobbet togs bort.");
-      setConfirmOpen(false);
-      router.push("/");
-      router.refresh();
-    } catch (deleteError) {
-      toast.error(deleteError instanceof Error ? deleteError.message : "Kunde inte ta bort annonsen.");
-      setIsDeleting(false);
-    }
+  function handleDelete() {
+    deleteJobMutation.mutate(jobId, {
+      onSuccess: () => {
+        toast.success("Jobbet togs bort.");
+        setConfirmOpen(false);
+        router.push("/");
+      },
+      onError: (error) => {
+        toast.error(error instanceof Error ? error.message : "Kunde inte ta bort annonsen.");
+      },
+    });
   }
 
-  if (!job && !error) {
+  if (isLoading) {
     return (
       <main className="flex min-h-svh flex-col items-center justify-center gap-3">
         <Loader size={40} />
@@ -74,12 +47,12 @@ export default function JobDetailPage({
     );
   }
 
-  if (!job) {
+  if (isError || !job) {
     return (
       <main className="min-h-svh pt-4">
         <section className="flex w-full max-w-3xl flex-col gap-4 p-5 sm:p-8 md:max-w-none">
           <h1 className="font-display text-4xl md:text-[2.4rem]">Jobbdetaljer</h1>
-          <p className="text-base text-app-muted sm:text-lg">{error}</p>
+          <p className="text-base text-app-muted sm:text-lg">Jobbet kunde inte hittas.</p>
           <Btn href="/" variant="secondary">
             Tillbaka
           </Btn>
@@ -160,7 +133,7 @@ export default function JobDetailPage({
           description="Det här går inte att ångra. Jobbet och all tillhörande information tas bort permanent."
           confirmLabel="Ta bort"
           onConfirm={() => void handleDelete()}
-          isLoading={isDeleting}
+          isLoading={deleteJobMutation.isPending}
         />
       </section>
     </main>

--- a/src/app/jobb/[jobId]/page.tsx
+++ b/src/app/jobb/[jobId]/page.tsx
@@ -7,7 +7,6 @@ import { Loader } from "@/components/ui/loader";
 import { StatusSelect } from "@/components/ui/status-select";
 import { ExternalLink, PencilLine, Trash2 } from "lucide-react";
 import { useDeleteJob, useJob } from "@/lib/hooks/jobs";
-import { ExternalLink, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { use, useState } from "react";
@@ -33,7 +32,11 @@ export default function JobDetailPage({
         router.push("/");
       },
       onError: (error) => {
-        toast.error(error instanceof Error ? error.message : "Kunde inte ta bort annonsen.");
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Kunde inte ta bort annonsen.",
+        );
       },
     });
   }
@@ -51,8 +54,12 @@ export default function JobDetailPage({
     return (
       <main className="min-h-svh pt-4">
         <section className="flex w-full max-w-3xl flex-col gap-4 p-5 sm:p-8 md:max-w-none">
-          <h1 className="font-display text-4xl md:text-[2.4rem]">Jobbdetaljer</h1>
-          <p className="text-base text-app-muted sm:text-lg">Jobbet kunde inte hittas.</p>
+          <h1 className="font-display text-4xl md:text-[2.4rem]">
+            Jobbdetaljer
+          </h1>
+          <p className="text-base text-app-muted sm:text-lg">
+            Jobbet kunde inte hittas.
+          </p>
           <Btn href="/" variant="secondary">
             Tillbaka
           </Btn>
@@ -65,52 +72,114 @@ export default function JobDetailPage({
     <main className="min-h-svh pt-4">
       <section className="flex flex-col gap-4 w-full">
         <h1 className="font-display text-4xl md:text-[2.4rem]">Jobbdetaljer</h1>
-        <p className="text-base text-app-muted sm:text-lg">Följ status, historik och nästa steg</p>
+        <p className="text-base text-app-muted sm:text-lg">
+          Följ status, historik och nästa steg
+        </p>
         <div className="flex flex-col gap-4">
           <article className="rounded-2xl border border-app-stroke bg-app-card p-4">
             <h2 className="font-display text-xl">{job.title}</h2>
             <div className="flex mt-2 gap-4">
-              <p className="w-full text-base text-app-muted"><strong>Företag</strong><br />{job.company}</p>
-              <p className="w-full text-base text-app-muted"><strong>Plats</strong><br />{job.location}</p>
+              <p className="w-full text-base text-app-muted">
+                <strong>Företag</strong>
+                <br />
+                {job.company}
+              </p>
+              <p className="w-full text-base text-app-muted">
+                <strong>Plats</strong>
+                <br />
+                {job.location}
+              </p>
             </div>
             <div className="flex mt-2 gap-4">
-              <p className="w-full text-base text-app-muted"><strong>Anställningsform</strong><br />{job.employmentType}</p>
-              <p className="w-full text-base text-app-muted"><strong>Omfattning</strong><br />{job.workload}</p>
+              <p className="w-full text-base text-app-muted">
+                <strong>Anställningsform</strong>
+                <br />
+                {job.employmentType}
+              </p>
+              <p className="w-full text-base text-app-muted">
+                <strong>Omfattning</strong>
+                <br />
+                {job.workload}
+              </p>
             </div>
-            {(job.contactPerson.name || job.contactPerson.role || job.contactPerson.email || job.contactPerson.phone) && (
-              <>
-                <h3 className="mt-3 font-display text-xl">Kontaktperson</h3>
-                {(job.contactPerson.name || job.contactPerson.role) && (
-                  <p className="text-base text-app-muted">
-                    {job.contactPerson.name && <strong>{job.contactPerson.name}</strong>}
-                    {job.contactPerson.name && job.contactPerson.role && " "}
-                    {job.contactPerson.role}
-                  </p>
-                )}
-                {job.contactPerson.email && (
-                  <p className="text-base text-app-muted"><strong>E-post:</strong> <Link href={`mailto:${job.contactPerson.email}`} className="font-medium text-app-cyan-strong">{job.contactPerson.email}</Link></p>
-                )}
-                {job.contactPerson.phone && (
-                  <p className="text-base text-app-muted"><strong>Telefon:</strong> <Link href={`tel:${job.contactPerson.phone}`} className="font-medium text-app-cyan-strong">{job.contactPerson.phone}</Link></p>
-                )}
-              </>
-            )}
+            {(job.contactPerson.name ||
+              job.contactPerson.role ||
+              job.contactPerson.email ||
+              job.contactPerson.phone) && (
+                <>
+                  <h3 className="mt-3 font-display text-xl">Kontaktperson</h3>
+                  {(job.contactPerson.name || job.contactPerson.role) && (
+                    <p className="text-base text-app-muted">
+                      {job.contactPerson.name && (
+                        <strong>{job.contactPerson.name}</strong>
+                      )}
+                      {job.contactPerson.name && job.contactPerson.role && " "}
+                      {job.contactPerson.role}
+                    </p>
+                  )}
+                  {job.contactPerson.email && (
+                    <p className="text-base text-app-muted">
+                      <strong>E-post:</strong>{" "}
+                      <Link
+                        href={`mailto:${job.contactPerson.email}`}
+                        className="font-medium text-app-cyan-strong"
+                      >
+                        {job.contactPerson.email}
+                      </Link>
+                    </p>
+                  )}
+                  {job.contactPerson.phone && (
+                    <p className="text-base text-app-muted">
+                      <strong>Telefon:</strong>{" "}
+                      <Link
+                        href={`tel:${job.contactPerson.phone}`}
+                        className="font-medium text-app-cyan-strong"
+                      >
+                        {job.contactPerson.phone}
+                      </Link>
+                    </p>
+                  )}
+                </>
+              )}
           </article>
           <div className="flex flex-col gap-3 sm:flex-row">
-            <Btn href={job.jobUrl} className="w-full" icon={ExternalLink} rel="noreferrer" target="_blank">Besök annons</Btn>
-            <Btn href={`/jobb/${job.id}/edit`} className="w-full" icon={PencilLine} variant="secondary">Redigera</Btn>
+            <Btn
+              href={job.jobUrl}
+              className="w-full"
+              icon={ExternalLink}
+              rel="noreferrer"
+              target="_blank"
+            >
+              Besök annons
+            </Btn>
+            <Btn
+              href={`/jobb/${job.id}/edit`}
+              className="w-full"
+              icon={PencilLine}
+              variant="secondary"
+            >
+              Redigera
+            </Btn>
           </div>
           <article className="rounded-2xl border border-app-stroke bg-app-card p-4">
             <h3 className="mb-2 text-xl font-display">Historik</h3>
             <div className="relative mt-2">
-              <div aria-hidden="true" className="absolute top-1 bottom-2 left-1.25 w-px bg-app-stroke" />
+              <div
+                aria-hidden="true"
+                className="absolute top-1 bottom-2 left-1.25 w-px bg-app-stroke"
+              />
               <ul className="space-y-4">
                 {job.timeline.map((item, index) => (
-                  <li key={`${job.title}-${item.date}-${index}`} className="relative flex gap-3 items-center">
+                  <li
+                    key={`${job.title}-${item.date}-${index}`}
+                    className="relative flex gap-3 items-center"
+                  >
                     <span className="mt-1 h-3 w-3 shrink-0 rounded-full bg-app-primary-strong ring-3 ring-app-card" />
                     <div>
-                    <strong className="block text-md text-app-muted">{item.date}</strong>
-                    <span className="text-lg">{item.event}</span>
+                      <strong className="block text-md text-app-muted">
+                        {item.date}
+                      </strong>
+                      <span className="text-lg">{item.event}</span>
                     </div>
                   </li>
                 ))}
@@ -120,8 +189,16 @@ export default function JobDetailPage({
           <StatusSelect jobId={job.id} initialStatus={job.status} />
         </div>
         <div className="flex w-full gap-4">
-          <Btn variant="secondary" className="w-1/2" href="/">Tillbaka</Btn>
-          <Btn type="button" variant="red" className="w-full" icon={Trash2} onClick={() => setConfirmOpen(true)}>
+          <Btn variant="secondary" className="w-1/2" href="/">
+            Tillbaka
+          </Btn>
+          <Btn
+            type="button"
+            variant="red"
+            className="w-full"
+            icon={Trash2}
+            onClick={() => setConfirmOpen(true)}
+          >
             Ta bort jobb
           </Btn>
         </div>

--- a/src/app/jobb/new/page.tsx
+++ b/src/app/jobb/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createJob } from "@/app/services/services";
+import { useCreateJob } from "@/lib/hooks/jobs";
 import { Btn } from "@/components/ui/btn";
 import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
@@ -140,9 +140,9 @@ function buildTimeline(form: JobFormState) {
 
 export default function NewJobPage() {
   const router = useRouter();
+  const createJob = useCreateJob();
   const [form, setForm] = useState<JobFormState>(initialState);
   const [isAutofilling, setIsAutofilling] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [feedback, setFeedback] = useState("");
   const [showManualFields, setShowManualFields] = useState(false);
   const [isDirectImportFlow, setIsDirectImportFlow] = useState(false);
@@ -280,42 +280,38 @@ export default function NewJobPage() {
     setForm((prev) => ({ ...prev, [field]: value }));
   }
 
-  async function submitJob() {
-    setIsSubmitting(true);
+  function submitJob() {
     setFeedback("");
 
-    try {
-      const payload: CreateJobInput = {
-        title: form.title,
-        company: form.company,
-        location: form.location,
-        employmentType: form.employmentType,
-        workload: form.workload,
-        jobUrl: form.jobUrl,
-        contactPerson: {
-          name: form.contactName,
-          role: form.contactRole,
-          email: form.contactEmail,
-          phone: form.contactPhone,
-        },
-        timeline: buildTimeline(form),
-        notes: form.notes,
-        status: form.status,
-      };
+    const payload: CreateJobInput = {
+      title: form.title,
+      company: form.company,
+      location: form.location,
+      employmentType: form.employmentType,
+      workload: form.workload,
+      jobUrl: form.jobUrl,
+      contactPerson: {
+        name: form.contactName,
+        role: form.contactRole,
+        email: form.contactEmail,
+        phone: form.contactPhone,
+      },
+      timeline: buildTimeline(form),
+      notes: form.notes,
+      status: form.status,
+    };
 
-      const createdJob = await createJob(payload);
-
-      toast.success("Jobbet lades till.");
-      router.push(`/jobb/${createdJob.id}`);
-      router.refresh();
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Kunde inte spara jobbet just nu.");
-      setFeedback(
-        error instanceof Error ? error.message : "Kunde inte spara jobbet just nu.",
-      );
-    } finally {
-      setIsSubmitting(false);
-    }
+    createJob.mutate(payload, {
+      onSuccess: (createdJob) => {
+        toast.success("Jobbet lades till.");
+        router.push(`/jobb/${createdJob.id}`);
+      },
+      onError: (error) => {
+        const message = error instanceof Error ? error.message : "Kunde inte spara jobbet just nu.";
+        toast.error(message);
+        setFeedback(message);
+      },
+    });
   }
 
   const handleSubmit: React.ComponentProps<"form">["onSubmit"] = (event) => {
@@ -558,8 +554,8 @@ export default function NewJobPage() {
                   <Btn href="/" variant="secondary" className="w-1/2">
                     Avbryt
                   </Btn>
-                  <Btn disabled={isSubmitting} type="submit" className="w-full" icon={Plus}>
-                    {isSubmitting ? "Sparar..." : "Lägg till jobb"}
+                  <Btn disabled={createJob.isPending} type="submit" className="w-full" icon={Plus}>
+                    {createJob.isPending ? "Sparar..." : "Lägg till jobb"}
                   </Btn>
                 </div>
               </div>

--- a/src/app/jobb/page.tsx
+++ b/src/app/jobb/page.tsx
@@ -1,27 +1,10 @@
-import type { Job } from "@/app/types";
-import { Btn } from "@/components/ui/btn";
-import { DeleteJobBtn } from "@/components/jobs/delete-job-btn";
 import { auth } from "@clerk/nextjs/server";
-import { Plus } from "lucide-react";
-import { headers } from "next/headers";
-import Link from "next/link";
 import { redirect } from "next/navigation";
-
-async function getJobs(cookieHeader: string): Promise<Job[]> {
-  const headersList = await headers();
-  const host = headersList.get("host") ?? "localhost:3000";
-  const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-
-  const res = await fetch(`${protocol}://${host}/api/jobs`, {
-    headers: { cookie: cookieHeader },
-    cache: "no-store",
-  });
-
-  if (!res.ok) return [];
-
-  const data = (await res.json()) as { applications: Job[] };
-  return data.applications;
-}
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { makeQueryClient } from "@/lib/hooks/query-client";
+import { jobKeys } from "@/lib/hooks/job-query-keys";
+import { getJobsServer } from "@/server/queries";
+import { JobsContent } from "@/components/jobs/jobs-content";
 
 export default async function JobsPage() {
   const { userId } = await auth();
@@ -30,48 +13,18 @@ export default async function JobsPage() {
     redirect("/sign-in");
   }
 
-  const headersList = await headers();
-  const jobs = await getJobs(headersList.get("cookie") ?? "");
+  const queryClient = makeQueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: jobKeys.all,
+    queryFn: getJobsServer,
+  });
 
   return (
     <main className="min-h-svh px-4 pt-4">
-      <section className="flex w-full flex-col gap-4">
-        <div className="flex items-center justify-between gap-3">
-          <h1 className="font-display text-4xl sm:text-6xl">Jobb</h1>
-          <Btn href="/jobb/new" icon={Plus}>Lägg till</Btn>
-        </div>
-
-        {jobs.length === 0 ? (
-          <p className="text-base text-app-muted">Inga jobb sparade än.</p>
-        ) : (
-          <ul className="space-y-2">
-            {jobs.map((job) => (
-              <li key={job.id} className="relative rounded-2xl border border-app-stroke bg-app-card transition hover:-translate-y-0.5 hover:shadow-sm">
-                <Link href={`/jobb/${job.id}`}>
-                  <span className="absolute inset-0 rounded-2xl" aria-hidden="true" />
-                  <span className="sr-only">Läs mer om {job.title}</span>
-                </Link>
-                <div className="flex items-center justify-between gap-2 p-4">
-                  <div className="min-w-0">
-                    <strong className="block truncate text-base leading-snug text-app-ink sm:text-lg">
-                      {job.title}
-                    </strong>
-                    <span className="mt-0.5 block truncate text-sm text-app-muted sm:text-base">
-                      {job.company}
-                    </span>
-                  </div>
-                  <div className="flex shrink-0 items-center gap-2">
-                    <span className="rounded-full bg-app-surface px-3 py-1 text-sm text-app-muted">
-                      {job.status}
-                    </span>
-                    <DeleteJobBtn jobId={job.id} />
-                  </div>
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <JobsContent />
+      </HydrationBoundary>
     </main>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { ClerkProvider } from "@clerk/nextjs";
 import { Bricolage_Grotesque, Inter, Geist } from "next/font/google";
 import "./globals.css";
 import { AppNavigationShell } from "@/components/navigation/bottom-nav";
+import { QueryProvider } from "@/components/providers/query-provider";
 import { RegisterServiceWorker } from "@/components/pwa/register-service-worker";
 import { Toaster } from "@/components/ui/sonner";
 import { cn } from "@/lib/utils";
@@ -65,9 +66,11 @@ export default function RootLayout({
         className={`${bricolageGrotesque.variable} ${inter.variable} min-h-svh antialiased`}
       >
         <ClerkProvider>
-          <RegisterServiceWorker />
-          <AppNavigationShell>{children}</AppNavigationShell>
-          <Toaster />
+          <QueryProvider>
+            <RegisterServiceWorker />
+            <AppNavigationShell>{children}</AppNavigationShell>
+            <Toaster />
+          </QueryProvider>
         </ClerkProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,26 +1,12 @@
 import { Btn } from "@/components/ui/btn";
-import { Pipeline, Statistics } from "@/components/dashboard";
-import type { Job } from "@/app/types";
 import { auth } from "@clerk/nextjs/server";
-import { headers } from "next/headers";
 import { Plus } from "lucide-react";
 import { redirect } from "next/navigation";
-
-async function getJobs(cookieHeader: string): Promise<Job[]> {
-  const headersList = await headers();
-  const host = headersList.get("host") ?? "localhost:3000";
-  const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-
-  const res = await fetch(`${protocol}://${host}/api/jobs`, {
-    headers: { cookie: cookieHeader },
-    cache: "no-store",
-  });
-
-  if (!res.ok) return [];
-
-  const data = (await res.json()) as { applications: Job[] };
-  return data.applications;
-}
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { makeQueryClient } from "@/lib/hooks/query-client";
+import { jobKeys } from "@/lib/hooks/job-query-keys";
+import { getJobsServer } from "@/server/queries";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 
 export default async function Home() {
   const { userId } = await auth();
@@ -29,8 +15,12 @@ export default async function Home() {
     redirect("/sign-in");
   }
 
-  const headersList = await headers();
-  const jobs = await getJobs(headersList.get("cookie") ?? "");
+  const queryClient = makeQueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: jobKeys.all,
+    queryFn: getJobsServer,
+  });
 
   return (
     <main className="min-h-svh">
@@ -45,8 +35,9 @@ export default async function Home() {
             </Btn>
           </div>
         </section>
-        <Pipeline jobs={jobs} />
-        <Statistics applications={jobs} />
+        <HydrationBoundary state={dehydrate(queryClient)}>
+          <DashboardContent />
+        </HydrationBoundary>
       </div>
     </main>
   );

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useJobs } from "@/lib/hooks/jobs";
+import { Pipeline, Statistics } from "@/components/dashboard";
+
+export function DashboardContent() {
+  const { data: jobs = [] } = useJobs();
+
+  return (
+    <>
+      <Pipeline jobs={jobs} />
+      <Statistics applications={jobs} />
+    </>
+  );
+}

--- a/src/components/jobs/delete-job-btn.tsx
+++ b/src/components/jobs/delete-job-btn.tsx
@@ -1,16 +1,14 @@
 "use client";
 
-import { deleteJob } from "@/app/services/services";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { useDeleteJob } from "@/lib/hooks/jobs";
 import { Trash2 } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
 export function DeleteJobBtn({ jobId }: Readonly<{ jobId: string }>) {
-  const router = useRouter();
   const [open, setOpen] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
+  const deleteJob = useDeleteJob();
 
   function handleTrigger(e: React.MouseEvent) {
     e.preventDefault();
@@ -18,18 +16,16 @@ export function DeleteJobBtn({ jobId }: Readonly<{ jobId: string }>) {
     setOpen(true);
   }
 
-  async function handleConfirm() {
-    setIsDeleting(true);
-
-    try {
-      await deleteJob(jobId);
-      toast.success("Jobbet togs bort.");
-      setOpen(false);
-      router.refresh();
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Kunde inte ta bort annonsen.");
-      setIsDeleting(false);
-    }
+  function handleConfirm() {
+    deleteJob.mutate(jobId, {
+      onSuccess: () => {
+        toast.success("Jobbet togs bort.");
+        setOpen(false);
+      },
+      onError: (err) => {
+        toast.error(err instanceof Error ? err.message : "Kunde inte ta bort annonsen.");
+      },
+    });
   }
 
   return (
@@ -49,8 +45,8 @@ export function DeleteJobBtn({ jobId }: Readonly<{ jobId: string }>) {
         title="Ta bort jobb?"
         description="Det här går inte att ångra. Jobbet och all tillhörande information tas bort permanent."
         confirmLabel="Ta bort"
-        onConfirm={() => void handleConfirm()}
-        isLoading={isDeleting}
+        onConfirm={handleConfirm}
+        isLoading={deleteJob.isPending}
       />
     </>
   );

--- a/src/components/jobs/jobs-content.tsx
+++ b/src/components/jobs/jobs-content.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useJobs } from "@/lib/hooks/jobs";
+import { Btn } from "@/components/ui/btn";
+import { DeleteJobBtn } from "@/components/jobs/delete-job-btn";
+import { Plus } from "lucide-react";
+import Link from "next/link";
+
+export function JobsContent() {
+  const { data: jobs = [] } = useJobs();
+
+  return (
+    <section className="flex w-full flex-col gap-4">
+      <div className="flex items-center justify-between gap-3">
+        <h1 className="font-display text-4xl sm:text-6xl">Jobb</h1>
+        <Btn href="/jobb/new" icon={Plus}>Lägg till</Btn>
+      </div>
+
+      {jobs.length === 0 ? (
+        <p className="text-base text-app-muted">Inga jobb sparade än.</p>
+      ) : (
+        <ul className="space-y-2">
+          {jobs.map((job) => (
+            <li key={job.id} className="relative rounded-2xl border border-app-stroke bg-app-card transition hover:-translate-y-0.5 hover:shadow-sm">
+              <Link href={`/jobb/${job.id}`}>
+                <span className="absolute inset-0 rounded-2xl" aria-hidden="true" />
+                <span className="sr-only">Läs mer om {job.title}</span>
+              </Link>
+              <div className="flex items-center justify-between gap-2 p-4">
+                <div className="min-w-0">
+                  <strong className="block truncate text-base leading-snug text-app-ink sm:text-lg">
+                    {job.title}
+                  </strong>
+                  <span className="mt-0.5 block truncate text-sm text-app-muted sm:text-base">
+                    {job.company}
+                  </span>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <span className="rounded-full bg-app-surface px-3 py-1 text-sm text-app-muted">
+                    {job.status}
+                  </span>
+                  <DeleteJobBtn jobId={job.id} />
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/providers/query-provider.tsx
+++ b/src/components/providers/query-provider.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { QueryClientProvider } from "@tanstack/react-query";
+import { useRef } from "react";
+import { makeQueryClient } from "@/lib/hooks/query-client";
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const ref = useRef<ReturnType<typeof makeQueryClient> | null>(null);
+  if (ref.current === null) ref.current = makeQueryClient();
+
+  return (
+    <QueryClientProvider client={ref.current}>{children}</QueryClientProvider>
+  );
+}

--- a/src/components/ui/status-select.tsx
+++ b/src/components/ui/status-select.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { updateJob } from "@/app/services/services";
 import { JobStatus } from "@/app/types";
+import { useUpdateJob } from "@/lib/hooks/jobs";
 import {
   Select,
   SelectContent,
@@ -9,7 +9,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -32,31 +31,31 @@ type StatusSelectProps = {
 };
 
 export function StatusSelect({ jobId, initialStatus }: Readonly<StatusSelectProps>) {
-  const router = useRouter();
   const [status, setStatus] = useState<JobStatus>(initialStatus);
+  const updateJob = useUpdateJob();
 
-  async function handleChange(nextStatus: string | null) {
+  function handleChange(nextStatus: string | null) {
     const resolvedStatus = (nextStatus ?? initialStatus) as JobStatus;
     const previousStatus = status;
 
-    if (resolvedStatus === previousStatus) {
-      return;
-    }
+    if (resolvedStatus === previousStatus) return;
 
     setStatus(resolvedStatus);
 
-    try {
-      await updateJob(jobId, { status: resolvedStatus });
-      toast.success(`Status ändrad till ${statusLabelByValue[resolvedStatus].toLowerCase()}.`);
-      router.refresh();
-    } catch (error) {
-      setStatus(previousStatus);
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : "Jobbet kunde inte uppdateras just nu.",
-      );
-    }
+    updateJob.mutate(
+      { id: jobId, updates: { status: resolvedStatus } },
+      {
+        onSuccess: () => {
+          toast.success(`Status ändrad till ${statusLabelByValue[resolvedStatus].toLowerCase()}.`);
+        },
+        onError: (error) => {
+          setStatus(previousStatus);
+          toast.error(
+            error instanceof Error ? error.message : "Jobbet kunde inte uppdateras just nu.",
+          );
+        },
+      },
+    );
   }
 
   return (

--- a/src/lib/hooks/job-query-keys.ts
+++ b/src/lib/hooks/job-query-keys.ts
@@ -1,0 +1,4 @@
+export const jobKeys = {
+  all: ["jobs"] as const,
+  detail: (id: string) => ["jobs", id] as const,
+};

--- a/src/lib/hooks/jobs.ts
+++ b/src/lib/hooks/jobs.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  createJob,
+  deleteJob,
+  getJob,
+  getJobs,
+  updateJob,
+} from "@/app/services/services";
+import type { CreateJobInput, UpdateJobInput } from "@/app/types";
+import { jobKeys } from "@/lib/hooks/job-query-keys";
+
+export function useJobs() {
+  return useQuery({
+    queryKey: jobKeys.all,
+    queryFn: getJobs,
+  });
+}
+
+export function useJob(id: string) {
+  return useQuery({
+    queryKey: jobKeys.detail(id),
+    queryFn: () => getJob(id),
+    enabled: Boolean(id),
+  });
+}
+
+export function useCreateJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateJobInput) => createJob(input),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: jobKeys.all });
+    },
+  });
+}
+
+export function useUpdateJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, updates }: { id: string; updates: UpdateJobInput }) =>
+      updateJob(id, updates),
+    onSuccess: (_data, { id }) => {
+      void queryClient.invalidateQueries({ queryKey: jobKeys.detail(id) });
+      void queryClient.invalidateQueries({ queryKey: jobKeys.all });
+    },
+  });
+}
+
+export function useDeleteJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteJob(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: jobKeys.all });
+    },
+  });
+}

--- a/src/lib/hooks/query-client.ts
+++ b/src/lib/hooks/query-client.ts
@@ -1,0 +1,12 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60_000,
+        gcTime: 300_000,
+      },
+    },
+  });
+}

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -1,0 +1,38 @@
+import prisma from "@/lib/prisma";
+import type { Job } from "@/app/types";
+import { JobStatus } from "@/app/types";
+import { auth } from "@clerk/nextjs/server";
+
+const prismaStatusToAppStatus: Record<string, JobStatus> = {
+  saved: JobStatus.SAVED,
+  applied: JobStatus.APPLIED,
+  in_process: JobStatus.IN_PROCESS,
+  interview: JobStatus.INTERVIEW,
+  offer: JobStatus.OFFER,
+  closed: JobStatus.CLOSED,
+};
+
+export async function getJobsServer(): Promise<Job[]> {
+  const { userId } = await auth();
+  if (!userId) return [];
+
+  const jobs = await prisma.job.findMany({
+    where: { userId },
+    include: { contactPerson: true, timeline: true },
+  });
+
+  return jobs.map((job) => ({
+    id: job.id,
+    userId: job.userId,
+    title: job.title,
+    company: job.company,
+    location: job.location,
+    employmentType: job.employmentType,
+    workload: job.workload,
+    jobUrl: job.jobUrl,
+    notes: job.notes ?? undefined,
+    status: prismaStatusToAppStatus[job.status] ?? JobStatus.SAVED,
+    contactPerson: job.contactPerson ?? { name: "", role: "", email: "", phone: "" },
+    timeline: job.timeline.map((t) => ({ date: t.date, event: t.event })),
+  }));
+}


### PR DESCRIPTION
- Migrates all client-side data fetching from ad-hoc `useEffect`/`useState` patterns to TanStack Query, enabling automatic caching, invalidation, and loading/error state management
- Adds custom hooks (`useJobs`, `useJob`, `useCreateJob`, `useUpdateJob`, `useDeleteJob`) with a shared query key factory in `src/lib/hooks/`
- Adds `src/server/queries.ts` for server-side Prisma-based job fetching in server components
- Fixes create-profile page to upsert instead of always creating, and pre-fills the form with existing data
