### PR TITLE
feat: expand PostHog tracking with proxy, page names, and button events

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,19 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: process.cwd(),
   },
+  async rewrites() {
+    return [
+      {
+        source: "/ingest/static/:path*",
+        destination: "https://eu-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/ingest/:path*",
+        destination: "https://eu.i.posthog.com/:path*",
+      },
+    ];
+  },
+  skipTrailingSlashRedirect: true,
 };
 
 export default withSentryConfig(nextConfig, {

--- a/src/app/jobb/[jobId]/edit/page.tsx
+++ b/src/app/jobb/[jobId]/edit/page.tsx
@@ -460,10 +460,10 @@ export default function EditJobPage({
             </label>
 
             <div className="flex gap-4">
-              <Btn href={`/jobb/${jobId}`} variant="secondary" className="w-1/2">
+              <Btn href={`/jobb/${jobId}`} variant="secondary" className="w-1/2" track="edit_job_cancel_click">
                 Avbryt
               </Btn>
-              <Btn disabled={updateJobMutation.isPending} type="submit" className="w-full" icon={Save}>
+              <Btn disabled={updateJobMutation.isPending} type="submit" className="w-full" icon={Save} track="save_job_click">
                 {updateJobMutation.isPending ? "Sparar..." : "Spara ändringar"}
               </Btn>
             </div>

--- a/src/app/jobb/[jobId]/page.tsx
+++ b/src/app/jobb/[jobId]/page.tsx
@@ -191,7 +191,7 @@ export default function JobDetailPage({
           <StatusSelect jobId={job.id} initialStatus={job.status} />
         </div>
         <div className="flex w-full gap-4">
-          <Btn variant="secondary" className="w-1/2" href="/">
+          <Btn variant="secondary" className="w-1/2" href="/" track="back_click">
             Tillbaka
           </Btn>
           <Btn

--- a/src/app/konto/page.tsx
+++ b/src/app/konto/page.tsx
@@ -42,11 +42,11 @@ export default async function AccountPage() {
       <section className='mx-auto flex w-full max-w-2xl flex-col gap-4 md:max-w-none'>
         <div>
           <h1 className='font-display text-4xl sm:text-6xl'>Konto</h1>
-          {profile?.name && (
+          {/*profile?.name && (
             <p className='mt-3 text-base text-app-muted sm:text-lg'>
               {profile.name}
             </p>
-          )}
+          )*/}
         </div>
 
         <article className='rounded-3xl border border-app-stroke bg-app-card p-5'>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { PostHogProvider } from "@/components/providers/posthog-provider";
 import { QueryProvider } from "@/components/providers/query-provider";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { PostHogPageView } from "@/components/analytics/posthog-page-view";
+import { PostHogServerPageView } from "@/components/analytics/posthog-server-page-view";
 import { RegisterServiceWorker } from "@/components/pwa/register-service-worker";
 import { Toaster } from "@/components/ui/sonner";
 import {
@@ -83,6 +84,7 @@ export default function RootLayout({
           <Script id="theme-preference-init" strategy="beforeInteractive">
             {themeInitializationScript}
           </Script>
+          <PostHogServerPageView />
           <Suspense fallback={null}>
             <PostHogPageView />
           </Suspense>

--- a/src/components/analytics/posthog-page-view.tsx
+++ b/src/components/analytics/posthog-page-view.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useSearchParams } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
 import { useEffect } from "react";
+import { getPageName } from "@/lib/page-names";
 
 export function PostHogPageView() {
   const pathname = usePathname();
@@ -13,7 +14,10 @@ export function PostHogPageView() {
     if (pathname && posthog) {
       const qs = searchParams.toString();
       const url = window.location.origin + pathname + (qs ? `?${qs}` : "");
-      posthog.capture("$pageview", { $current_url: url });
+      posthog.capture("$pageview", {
+        $current_url: url,
+        page_name: getPageName(pathname),
+      });
     }
   }, [pathname, searchParams, posthog]);
 

--- a/src/components/analytics/posthog-server-page-view.tsx
+++ b/src/components/analytics/posthog-server-page-view.tsx
@@ -1,0 +1,22 @@
+import { headers } from "next/headers";
+import { getPostHogServer } from "@/lib/posthog-server";
+import { getPageName } from "@/lib/page-names";
+
+export async function PostHogServerPageView() {
+  const headersList = await headers();
+  const pathname = headersList.get("x-pathname") ?? "/";
+
+  const posthog = getPostHogServer();
+  posthog.capture({
+    distinctId: "anonymous",
+    event: "$pageview",
+    properties: {
+      $current_url: pathname,
+      page_name: getPageName(pathname),
+      $process_person_profile: false,
+    },
+  });
+  await posthog.flush();
+
+  return null;
+}

--- a/src/components/auth/auth-page-client.tsx
+++ b/src/components/auth/auth-page-client.tsx
@@ -180,13 +180,14 @@ export default function AuthPageClient() {
                   <p className="mt-2 text-sm text-red-500">{feedback}</p>
                 )}
               </div>
-              <Btn className="w-full" disabled={loading !== null} type="submit">
+              <Btn className="w-full" disabled={loading !== null} track="auth_verify_click" type="submit">
                 {loading === "verify" ? "Verifierar..." : "Fortsätt"}
               </Btn>
               <div className="flex items-center justify-center gap-4">
                 <Btn
                   type="button"
                   disabled={loading !== null}
+                  track="auth_resend_code_click"
                   onClick={async () => {
                     setFeedBack("");
                     setLoading("resend");
@@ -200,6 +201,7 @@ export default function AuthPageClient() {
                 <Btn
                   type="button"
                   disabled={loading !== null}
+                  track="auth_reset_click"
                   onClick={() => {
                     signIn.reset();
                     setVerifying(false);
@@ -252,7 +254,7 @@ export default function AuthPageClient() {
               </p>
             ) : null}
 
-            <Btn className="w-full" disabled={loading !== null} type="submit">
+            <Btn className="w-full" disabled={loading !== null} track="auth_submit_click" type="submit">
               {loading === "submit" ? "Loggar in..." : "Fortsätt"}
             </Btn>
             <div id="clerk-captcha" />

--- a/src/components/auth/logout-btn.tsx
+++ b/src/components/auth/logout-btn.tsx
@@ -2,6 +2,7 @@
 
 import { Btn } from "@/components/ui/btn";
 import { useClerk } from "@clerk/nextjs";
+import posthog from "posthog-js";
 
 type LogoutBtnProps = {
   className?: string;
@@ -13,7 +14,10 @@ export function LogoutBtn({ className }: Readonly<LogoutBtnProps>) {
   return (
     <Btn
       className={className}
-      onClick={() => signOut({ redirectUrl: "/" })}
+      onClick={() => {
+        posthog.capture("logout_click", undefined, { send_instantly: true });
+        signOut({ redirectUrl: "/" });
+      }}
       variant="red"
     >
       Logga ut

--- a/src/components/dashboard/add-job-btn.tsx
+++ b/src/components/dashboard/add-job-btn.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { trackEvent } from "@/lib/analytics";
 import { Btn } from "@/components/ui/btn";
 import { Plus } from "lucide-react";
 
@@ -10,7 +9,7 @@ export function AddJobBtn() {
       className="md:hidden"
       href="/jobb/new"
       icon={Plus}
-      onClick={() => trackEvent("add_job_click", { location: "dashboard" })}
+      track="add_job_click"
     >
       Lägg till jobb
     </Btn>

--- a/src/components/jobs/delete-job-btn.tsx
+++ b/src/components/jobs/delete-job-btn.tsx
@@ -2,6 +2,7 @@
 
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { useDeleteJob } from "@/lib/hooks/jobs";
+import { trackEvent } from "@/lib/analytics";
 import { Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -13,6 +14,7 @@ export function DeleteJobBtn({ jobId }: Readonly<{ jobId: string }>) {
   function handleTrigger(e: React.MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
+    trackEvent("delete_job_click");
     setOpen(true);
   }
 

--- a/src/components/jobs/jobs-content.tsx
+++ b/src/components/jobs/jobs-content.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useJobs } from "@/lib/hooks/jobs";
-import { trackEvent } from "@/lib/analytics";
 import { Btn } from "@/components/ui/btn";
 import { DeleteJobBtn } from "@/components/jobs/delete-job-btn";
 import { Plus } from "lucide-react";
@@ -14,7 +13,7 @@ export function JobsContent() {
     <section className="flex w-full flex-col gap-4">
       <div className="flex items-center justify-between gap-3">
         <h1 className="font-display text-4xl sm:text-6xl">Jobb</h1>
-        <Btn href="/jobb/new" icon={Plus} onClick={() => trackEvent("add_job_click", { location: "jobs-list" })}>Lägg till</Btn>
+        <Btn href="/jobb/new" icon={Plus} track="add_job_click">Lägg till</Btn>
       </div>
 
       {jobs.length === 0 ? (

--- a/src/components/navigation/bottom-nav.tsx
+++ b/src/components/navigation/bottom-nav.tsx
@@ -160,7 +160,7 @@ export function AppNavigationShell({
                 </div>
 
                 <div className="mt-auto flex flex-col gap-3 pt-6">
-                  <Btn className="w-full" href="/jobb/new" icon={Plus}>
+                  <Btn className="w-full" href="/jobb/new" icon={Plus} track="add_job_click">
                     Lägg till jobb
                   </Btn>
                   <LogoutBtn className="w-full" />

--- a/src/components/providers/posthog-provider.tsx
+++ b/src/components/providers/posthog-provider.tsx
@@ -2,18 +2,18 @@
 
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
-import { useEffect } from "react";
+
+if (typeof window !== "undefined") {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    person_profiles: "never",        // fully anonymous — no user profiles created
+    capture_pageview: false,          // handled manually via PostHogPageView (App Router)
+    disable_session_recording: true,  // Sentry handles session replays
+    autocapture: false,               // manual events only — keeps monthly quota predictable
+    persistence: "memory",            // no cookie/localStorage — ID resets each session, GDPR-safe
+  });
+}
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
-  useEffect(() => {
-    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-      person_profiles: "never",        // fully anonymous — no user profiles created
-      capture_pageview: false,          // handled manually via PostHogPageView (App Router)
-      disable_session_recording: true,  // Sentry handles session replays
-      autocapture: false,               // manual events only — keeps monthly quota predictable
-    });
-  }, []);
-
   return <PHProvider client={posthog}>{children}</PHProvider>;
 }

--- a/src/components/report/applied-jobs-page-client.tsx
+++ b/src/components/report/applied-jobs-page-client.tsx
@@ -17,7 +17,7 @@ export function AppliedJobsPageClient({ jobs }: Readonly<AppliedJobsPageClientPr
           <p className="text-lg text-app-muted">
             Det finns inga registrerade ansökningar att visa ännu.
           </p>
-          <Btn href="/" variant="secondary">
+          <Btn href="/" variant="secondary" track="back_click">
             Tillbaka
           </Btn>
         </section>

--- a/src/components/report/report-page-client.tsx
+++ b/src/components/report/report-page-client.tsx
@@ -333,6 +333,7 @@ export function ReportPageClient({ jobs, options }: Readonly<ReportPageClientPro
                 target="_blank"
                 rel="noreferrer"
                 icon={{ component: ExternalLink, position: "right", size: 18 }}
+                track="install_extension_click"
               >
                 {installTarget.installLabel}
               </Btn>

--- a/src/components/ui/btn.tsx
+++ b/src/components/ui/btn.tsx
@@ -1,5 +1,8 @@
+"use client"
+
 import type { LucideIcon } from 'lucide-react'
 import Link from 'next/link'
+import { trackButtonEvent, type TrackableEvent } from '@/lib/analytics'
 
 type BtnVariant = "primary" | "secondary" | "tertiary" | "red" | "muted";
 type BtnIconPosition = "left" | "right";
@@ -21,6 +24,7 @@ type SharedProps = {
   hex?: string
   icon?: BtnIconProp
   style?: React.CSSProperties
+  track?: TrackableEvent
   variant?: BtnVariant
 }
 
@@ -118,6 +122,7 @@ export function Btn({
   hex,
   icon,
   style,
+  track,
   variant = "primary",
   ...props
 }: BtnProps) {
@@ -176,6 +181,7 @@ export function Btn({
           rel={rel}
           style={resolvedStyle}
           target={target}
+          onClick={() => { if (track) trackButtonEvent(track); }}
         >
           {content}
         </a>
@@ -183,14 +189,28 @@ export function Btn({
     }
 
     return (
-      <Link className={classes} href={href} style={resolvedStyle}>
+      <Link
+        className={classes}
+        href={href}
+        style={resolvedStyle}
+        onClick={() => { if (track) trackButtonEvent(track); }}
+      >
         {content}
       </Link>
     );
   }
 
+  const { onClick, ...buttonProps } = props as ButtonBtnProps;
   return (
-    <button className={classes} style={resolvedStyle} {...props}>
+    <button
+      className={classes}
+      style={resolvedStyle}
+      {...buttonProps}
+      onClick={(e) => {
+        if (track) trackButtonEvent(track);
+        onClick?.(e);
+      }}
+    >
       {content}
     </button>
   );

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,16 +1,50 @@
 import posthog from "posthog-js";
 
+/**
+ * All trackable PostHog events.
+ *
+ * How to add a new tracked button:
+ *   1. Add the event key (and optional properties) to AnalyticsEvents below.
+ *   2. Pass it as the `track` prop on <Btn>:
+ *        <Btn track="my_new_event">Click me</Btn>
+ *   3. If you need to attach runtime properties, use trackEvent() in onClick instead:
+ *        <Btn onClick={() => trackEvent("add_job_click", { location: "dashboard" })}>...</Btn>
+ */
 type AnalyticsEvents = {
-  add_job_click: { location: "dashboard" | "jobs-list" };
+  // Job actions
+  add_job_click: { location?: "dashboard" | "jobs-list" };
   visit_posting_click: undefined;
   edit_job_click: undefined;
+  save_job_click: undefined;
+  edit_job_cancel_click: undefined;
   delete_job_click: undefined;
   manual_entry_click: undefined;
+
+  // Auth
+  auth_submit_click: undefined;
+  auth_verify_click: undefined;
+  auth_resend_code_click: undefined;
+  auth_reset_click: undefined;
+  logout_click: undefined;
+
+  // Navigation
+  back_click: undefined;
+
+  // Report / Extensions
+  install_extension_click: undefined;
 };
 
+export type TrackableEvent = keyof AnalyticsEvents;
+
+/** Fire a named event with optional typed properties. */
 export function trackEvent<E extends keyof AnalyticsEvents>(
   event: E,
-  ...args: AnalyticsEvents[E] extends undefined ? [] : [properties: AnalyticsEvents[E]]
+  ...args: AnalyticsEvents[E] extends undefined ? [] : [properties?: AnalyticsEvents[E]]
 ): void {
   posthog.capture(event, args[0]);
+}
+
+/** Fire a named event with no properties. Used internally by <Btn track="…">. */
+export function trackButtonEvent(event: TrackableEvent): void {
+  posthog.capture(event);
 }

--- a/src/lib/page-names.ts
+++ b/src/lib/page-names.ts
@@ -1,0 +1,20 @@
+type RouteEntry = { pattern: RegExp | string; name: string };
+
+const ROUTES: RouteEntry[] = [
+  { pattern: "/", name: "Dashboard" },
+  { pattern: "/jobb/new", name: "New Application" },
+  { pattern: /^\/jobb\/[^/]+$/, name: "Application Detail" },
+  { pattern: "/konto/create-profile", name: "Create Profile" },
+  { pattern: "/konto", name: "Account" },
+  { pattern: "/aktivitetsrapport", name: "Activity Report" },
+  { pattern: "/report", name: "Report" },
+];
+
+export function getPageName(pathname: string): string {
+  for (const { pattern, name } of ROUTES) {
+    if (typeof pattern === "string" ? pathname === pattern : pattern.test(pathname)) {
+      return name;
+    }
+  }
+  return pathname;
+}

--- a/src/lib/posthog-server.ts
+++ b/src/lib/posthog-server.ts
@@ -5,7 +5,7 @@ let client: PostHog | null = null;
 export function getPostHogServer(): PostHog {
   if (!client) {
     client = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-      host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+      host: "https://eu.i.posthog.com",
       flushAt: 1,       // send immediately — critical in serverless (no persistent process)
       flushInterval: 0, // no batching delay
     });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -35,13 +35,15 @@ export default clerkMiddleware(async (auth, req) => {
       }
     }
   }
+
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set("x-pathname", req.nextUrl.pathname);
+  return NextResponse.next({ request: { headers: requestHeaders } });
 });
 
 export const config = {
   matcher: [
-    // Skip Next.js internals and all static files, unless found in search params
     "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
-    // Always run for API routes
     "/(api|trpc)(.*)",
   ],
 };


### PR DESCRIPTION
- Route PostHog through Next.js proxy rewrites for ad-blocker resilience
- Add typed `track` prop to <Btn> for declarative event capture across the app
- Track auth flow buttons (submit, verify, resend, reset) and job detail/edit buttons
- Fix logout tracking using `send_instantly` so the event fires before Clerk redirects
- Switch PostHog to memory persistence (GDPR-safe) and add server-side page view tracking with human-readable page names