### PR TITLE
feat: add first-visit GDPR cookie notice banner

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { PostHogPageView } from "@/components/analytics/posthog-page-view";
 import { PostHogServerPageView } from "@/components/analytics/posthog-server-page-view";
 import { RegisterServiceWorker } from "@/components/pwa/register-service-worker";
 import { Toaster } from "@/components/ui/sonner";
+import { CookieNotice } from "@/components/gdpr/cookie-notice";
 import {
   DEFAULT_THEME_PREFERENCE,
   themeInitializationScript,
@@ -94,6 +95,7 @@ export default function RootLayout({
                 <RegisterServiceWorker />
                 <AppNavigationShell>{children}</AppNavigationShell>
                 <Toaster />
+                <CookieNotice />
               </QueryProvider>
             </ThemeProvider>
           </ClerkProvider>

--- a/src/components/gdpr/cookie-notice.tsx
+++ b/src/components/gdpr/cookie-notice.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useEffect } from "react";
+
+const STORAGE_KEY = "cookie-notice-dismissed";
+
+export function CookieNotice() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!localStorage.getItem(STORAGE_KEY)) {
+      setVisible(true);
+    }
+  }, []);
+
+  function dismiss() {
+    localStorage.setItem(STORAGE_KEY, "1");
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed right-0 bottom-[var(--mobile-bottom-nav-clearance)] left-0 z-50 p-3 md:bottom-0 md:p-4">
+      <div className="mx-auto flex max-w-3xl items-start gap-3 rounded-xl border border-app-stroke bg-app-card px-4 py-3 shadow-lg">
+        <p className="flex-1 text-sm text-app-ink">
+          Den här appen använder cookies för inloggning. Inga spårningscookies
+          används.{" "}
+          <Link
+            href="/gdpr"
+            className="text-app-primary underline underline-offset-2"
+          >
+            Läs mer
+          </Link>
+        </p>
+        <button
+          onClick={dismiss}
+          aria-label="Stäng"
+          className="shrink-0 cursor-pointer pt-0.5 leading-none text-app-muted transition-colors hover:text-app-ink"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- New CookieNotice component shown on first visit, dismissed via localStorage
- Informs users that only auth cookies (Clerk) are used, no tracking cookies
- Links to /gdpr for full privacy details
- Positioned above mobile nav using --mobile-bottom-nav-clearance, flush bottom on desktop