### PR TITLE
Feat/onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ CLAUDE.md
 
 # local VS Code MCP config can contain secrets
 /.vscode/mcp.json
+/.superpowers/brainstorm
+/docs/superpowers/specs
+/docs/superpowers/plans

--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ CLAUDE.md
 # local VS Code MCP config can contain secrets
 /.vscode/mcp.json
 /.superpowers/brainstorm
+/.worktrees
 /docs/superpowers/specs
 /docs/superpowers/plans

--- a/prisma/migrations/20260409120000_add_onboarding_flags/migration.sql
+++ b/prisma/migrations/20260409120000_add_onboarding_flags/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "onboardingDismissed" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "User" ADD COLUMN     "onboardingPipelineExplored" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "User" ADD COLUMN     "onboardingReportViewed" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,9 @@ model User {
   tipNotificationsEnabled  Boolean @default(true)
   termsAcceptedAt DateTime?
   termsVersion    String?
+  onboardingDismissed        Boolean  @default(false)
+  onboardingPipelineExplored Boolean  @default(false)
+  onboardingReportViewed     Boolean  @default(false)
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
 

--- a/src/app/aktivitetsrapport/page.tsx
+++ b/src/app/aktivitetsrapport/page.tsx
@@ -1,6 +1,8 @@
 import { getReportPageData } from "@/app/report/report-page-data";
 import type { Job } from "@/app/types";
 import { ReportPageClient } from "@/components/report/report-page-client";
+import { ReportViewedTracker } from "@/components/report/report-viewed-tracker";
+import { getUserOnboardingFlags } from "@/server/queries";
 import { auth } from "@clerk/nextjs/server";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
@@ -31,7 +33,10 @@ export default async function ActivityReportPage() {
   }
 
   const headersList = await headers();
-  const applications = await getJobs(headersList.get("cookie") ?? "");
+  const [applications, userFlags] = await Promise.all([
+    getJobs(headersList.get("cookie") ?? ""),
+    getUserOnboardingFlags(),
+  ]);
 
   if (applications.length === 0) {
     redirect("/jobb/new");
@@ -39,5 +44,11 @@ export default async function ActivityReportPage() {
 
   const { jobs, options } = getReportPageData(applications);
 
-  return <ReportPageClient jobs={jobs} options={options} />;
+  return (
+    <>
+      {/* Default to true when userFlags is null: no profile means PATCH would fail anyway */}
+      <ReportViewedTracker alreadyTracked={userFlags?.onboardingReportViewed ?? true} />
+      <ReportPageClient jobs={jobs} options={options} />
+    </>
+  );
 }

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -15,6 +15,9 @@ type User = {
   id: string;
   termsAcceptedAt: Date | null;
   termsVersion: string | null;
+  onboardingDismissed: boolean;
+  onboardingPipelineExplored: boolean;
+  onboardingReportViewed: boolean;
 };
 
 const userSelect = {
@@ -26,6 +29,9 @@ const userSelect = {
   role: true,
   termsAcceptedAt: true,
   termsVersion: true,
+  onboardingDismissed: true,
+  onboardingPipelineExplored: true,
+  onboardingReportViewed: true,
 } as const;
 
 export async function GET(
@@ -146,4 +152,62 @@ export async function POST(
   }
 
   return NextResponse.json(userData as User, { status: 201 });
+}
+
+type PatchUserInput = {
+  onboardingDismissed?: boolean;
+  onboardingPipelineExplored?: boolean;
+  onboardingReportViewed?: boolean;
+};
+
+export async function PATCH(
+  req: NextRequest,
+): Promise<NextResponse<{ ok: boolean } | { error: string }>> {
+  const clerkUser = await currentUser();
+
+  if (!clerkUser) {
+    return NextResponse.json({ error: "Inte autentiserad." }, { status: 401 });
+  }
+
+  const email = clerkUser.emailAddresses[0]?.emailAddress;
+
+  if (!email) {
+    return NextResponse.json(
+      { error: "Ingen e-postadress hittades." },
+      { status: 400 },
+    );
+  }
+
+  const body = (await req.json()) as PatchUserInput;
+  const update: Partial<PatchUserInput> = {};
+
+  if (typeof body.onboardingDismissed === "boolean") {
+    update.onboardingDismissed = body.onboardingDismissed;
+  }
+  if (typeof body.onboardingPipelineExplored === "boolean") {
+    update.onboardingPipelineExplored = body.onboardingPipelineExplored;
+  }
+  if (typeof body.onboardingReportViewed === "boolean") {
+    update.onboardingReportViewed = body.onboardingReportViewed;
+  }
+
+  if (Object.keys(update).length === 0) {
+    return NextResponse.json(
+      { error: "Inga fält att uppdatera." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await prisma.user.update({ where: { id: clerkUser.id }, data: update });
+  } catch (err) {
+    logger.error("Failed to update onboarding flags", { userId: clerkUser.id });
+    Sentry.captureException(err, { tags: { route: "PATCH /api/user" } });
+    return NextResponse.json(
+      { error: "Det gick inte att uppdatera profilen." },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
 }

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -169,15 +169,7 @@ export async function PATCH(
     return NextResponse.json({ error: "Inte autentiserad." }, { status: 401 });
   }
 
-  const email = clerkUser.emailAddresses[0]?.emailAddress;
-
-  if (!email) {
-    return NextResponse.json(
-      { error: "Ingen e-postadress hittades." },
-      { status: 400 },
-    );
-  }
-
+  // id is always the Clerk user ID — POST /api/user sets it explicitly on create
   const body = (await req.json()) as PatchUserInput;
   const update: Partial<PatchUserInput> = {};
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,8 +4,15 @@ import { AddJobBtn } from "@/components/dashboard/add-job-btn";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { makeQueryClient } from "@/lib/hooks/query-client";
 import { jobKeys } from "@/lib/hooks/job-query-keys";
-import { getJobsServer } from "@/server/queries";
+import { getJobsServer, getUserOnboardingFlags } from "@/server/queries";
 import { DashboardContent } from "@/components/dashboard/dashboard-content";
+import type { UserOnboardingFlags } from "@/app/types";
+
+const DEFAULT_FLAGS: UserOnboardingFlags = {
+  onboardingDismissed: false,
+  onboardingPipelineExplored: false,
+  onboardingReportViewed: false,
+};
 
 export default async function DashboardPage() {
   const { userId } = await auth();
@@ -16,10 +23,13 @@ export default async function DashboardPage() {
 
   const queryClient = makeQueryClient();
 
-  await queryClient.prefetchQuery({
-    queryKey: jobKeys.all(),
-    queryFn: () => getJobsServer(),
-  });
+  const [, userFlags] = await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: jobKeys.all(),
+      queryFn: () => getJobsServer(),
+    }),
+    getUserOnboardingFlags(),
+  ]);
 
   return (
     <main className="min-h-svh">
@@ -33,7 +43,7 @@ export default async function DashboardPage() {
           </div>
         </section>
         <HydrationBoundary state={dehydrate(queryClient)}>
-          <DashboardContent />
+          <DashboardContent userFlags={userFlags ?? DEFAULT_FLAGS} />
         </HydrationBoundary>
       </div>
     </main>

--- a/src/app/konto/create-profile/page.tsx
+++ b/src/app/konto/create-profile/page.tsx
@@ -39,6 +39,10 @@ export default function CreateProfilePage() {
         const res = await fetch('/api/user');
         if (res.ok) {
           const data = (await res.json()) as ExistingProfile;
+          if (data.termsVersion === TERMS_VERSION) {
+            router.replace('/dashboard');
+            return;
+          }
           setExistingProfile(data);
           setForm({ name: data.name, profession: data.profession });
         }
@@ -49,7 +53,7 @@ export default function CreateProfilePage() {
       }
     }
     void fetchProfile();
-  }, []);
+  }, [router]);
 
   const needsTermsUpdate =
     existingProfile !== null && existingProfile.termsVersion !== TERMS_VERSION;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,51 +1,18 @@
 import { auth } from "@clerk/nextjs/server";
-import { redirect } from "next/navigation";
-import { AddJobBtn } from "@/components/dashboard/add-job-btn";
-import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
-import { makeQueryClient } from "@/lib/hooks/query-client";
-import { jobKeys } from "@/lib/hooks/job-query-keys";
-import { getJobsServer, getUserOnboardingFlags } from "@/server/queries";
-import { DashboardContent } from "@/components/dashboard/dashboard-content";
-import type { UserOnboardingFlags } from "@/app/types";
 
-const DEFAULT_FLAGS: UserOnboardingFlags = {
-  onboardingDismissed: false,
-  onboardingPipelineExplored: false,
-  onboardingReportViewed: false,
-};
+import { LandingPage } from "@/components/landing/landing-page";
+import { getHeroHighlights } from "@/lib/job-insights";
+import { getLandingJobsServer } from "@/server/queries";
 
 export default async function Home() {
   const { userId } = await auth();
-
-  if (!userId) {
-    redirect("/sign-in");
-  }
-
-  const queryClient = makeQueryClient();
-
-  const [, userFlags] = await Promise.all([
-    queryClient.prefetchQuery({
-      queryKey: jobKeys.all(),
-      queryFn: () => getJobsServer(),
-    }),
-    getUserOnboardingFlags(),
-  ]);
+  const jobs = await getLandingJobsServer();
+  const heroHighlights = getHeroHighlights(jobs);
 
   return (
-    <main className="min-h-svh">
-      <div className="w-full">
-        <section className="w-full">
-          <div className="flex items-center justify-between gap-3">
-            <h1 className="font-display text-4xl leading-none md:hidden">
-              Jobi<span className="text-app-primary">.sh</span>
-            </h1>
-            <AddJobBtn />
-          </div>
-        </section>
-        <HydrationBoundary state={dehydrate(queryClient)}>
-          <DashboardContent userFlags={userFlags ?? DEFAULT_FLAGS} />
-        </HydrationBoundary>
-      </div>
-    </main>
+    <LandingPage
+      heroHighlights={heroHighlights}
+      signedIn={Boolean(userId)}
+    />
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,51 @@
 import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { AddJobBtn } from "@/components/dashboard/add-job-btn";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { makeQueryClient } from "@/lib/hooks/query-client";
+import { jobKeys } from "@/lib/hooks/job-query-keys";
+import { getJobsServer, getUserOnboardingFlags } from "@/server/queries";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
+import type { UserOnboardingFlags } from "@/app/types";
 
-import { LandingPage } from "@/components/landing/landing-page";
-import { getHeroHighlights } from "@/lib/job-insights";
-import { getLandingJobsServer } from "@/server/queries";
+const DEFAULT_FLAGS: UserOnboardingFlags = {
+  onboardingDismissed: false,
+  onboardingPipelineExplored: false,
+  onboardingReportViewed: false,
+};
 
 export default async function Home() {
   const { userId } = await auth();
-  const jobs = await getLandingJobsServer();
-  const heroHighlights = getHeroHighlights(jobs);
+
+  if (!userId) {
+    redirect("/sign-in");
+  }
+
+  const queryClient = makeQueryClient();
+
+  const [, userFlags] = await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: jobKeys.all(),
+      queryFn: () => getJobsServer(),
+    }),
+    getUserOnboardingFlags(),
+  ]);
 
   return (
-    <LandingPage
-      heroHighlights={heroHighlights}
-      signedIn={Boolean(userId)}
-    />
+    <main className="min-h-svh">
+      <div className="w-full">
+        <section className="w-full">
+          <div className="flex items-center justify-between gap-3">
+            <h1 className="font-display text-4xl leading-none md:hidden">
+              Jobi<span className="text-app-primary">.sh</span>
+            </h1>
+            <AddJobBtn />
+          </div>
+        </section>
+        <HydrationBoundary state={dehydrate(queryClient)}>
+          <DashboardContent userFlags={userFlags ?? DEFAULT_FLAGS} />
+        </HydrationBoundary>
+      </div>
+    </main>
   );
 }

--- a/src/app/services/services.ts
+++ b/src/app/services/services.ts
@@ -1,4 +1,4 @@
-import type { CreateJobInput, Job, UpdateJobInput } from "../types";
+import type { CreateJobInput, Job, UpdateJobInput, UserOnboardingFlags } from "../types";
 
 const API_BASE = "/api/jobs";
 
@@ -79,5 +79,19 @@ export async function deleteJob(id: string): Promise<void> {
   });
   if (!res.ok) {
     throw new Error(await getErrorMessage(res, `Failed to delete job ${id}`));
+  }
+}
+
+type PatchUserInput = Partial<UserOnboardingFlags>;
+
+/** PATCH onboarding flags on the current user */
+export async function patchUser(input: PatchUserInput): Promise<void> {
+  const res = await fetch("/api/user", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    throw new Error(await getErrorMessage(res, "Failed to update user"));
   }
 }

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -98,3 +98,9 @@ export type Db = {
   applications: Job[];
 };
 
+export type UserOnboardingFlags = {
+  onboardingDismissed: boolean;
+  onboardingPipelineExplored: boolean;
+  onboardingReportViewed: boolean;
+};
+

--- a/src/components/auth/auth-page-client.tsx
+++ b/src/components/auth/auth-page-client.tsx
@@ -40,7 +40,7 @@ export default function AuthPageClient() {
   );
 
   const navigate = (decorateUrl: (url: string) => string) => {
-    const url = decorateUrl("/");
+    const url = decorateUrl(process.env.NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL || "/dashboard");
     if (url.startsWith("http")) {
       globalThis.location.href = url;
     } else {

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -1,13 +1,42 @@
 "use client";
 
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
 import { useJobs } from "@/lib/hooks/jobs";
 import { Pipeline, Statistics } from "@/components/dashboard";
+import { OnboardingChecklist } from "@/components/dashboard/onboarding-checklist";
+import { patchUser } from "@/app/services/services";
+import type { UserOnboardingFlags } from "@/app/types";
 
-export function DashboardContent() {
-  const { data: jobs = [] } = useJobs();
+export function DashboardContent({
+  userFlags,
+}: {
+  userFlags: UserOnboardingFlags;
+}) {
+  const { data: jobs = [], isLoading } = useJobs();
+  const router = useRouter();
+  const hasTrackedPipeline = useRef(false);
+
+  useEffect(() => {
+    if (
+      !isLoading &&
+      jobs.length > 0 &&
+      !userFlags.onboardingPipelineExplored &&
+      !hasTrackedPipeline.current
+    ) {
+      hasTrackedPipeline.current = true;
+      patchUser({ onboardingPipelineExplored: true })
+        .then(() => router.refresh())
+        .catch(() => {
+          hasTrackedPipeline.current = false;
+        });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading, jobs.length, userFlags.onboardingPipelineExplored]);
 
   return (
     <>
+      <OnboardingChecklist jobs={jobs} userFlags={userFlags} />
       <Pipeline jobs={jobs} />
       <Statistics applications={jobs} />
     </>

--- a/src/components/dashboard/onboarding-checklist.tsx
+++ b/src/components/dashboard/onboarding-checklist.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { CheckCircle2 } from "lucide-react";
 import type { Job, UserOnboardingFlags } from "@/app/types";
@@ -62,8 +62,27 @@ export function OnboardingChecklist({
     }
   }
 
-  if (dismissed || userFlags.onboardingDismissed || allDone) {
+  if (dismissed || userFlags.onboardingDismissed) {
     return null;
+  }
+
+  if (allDone) {
+    return (
+      <article className="mt-4 rounded-2xl border border-app-stroke bg-app-green p-4">
+        <div className="mb-1 flex items-center justify-between">
+          <h3 className="font-display text-xl text-app-green-strong">Du är redo!</h3>
+        </div>
+        <p className="mb-4 text-sm text-app-green-strong">
+          Du har gått igenom alla steg och är redo att använda Jobi.sh fullt ut.
+        </p>
+        <button
+          onClick={handleDismiss}
+          className="w-full cursor-pointer rounded-xl bg-app-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-app-primary-strong"
+        >
+          Stäng
+        </button>
+      </article>
+    );
   }
 
   return (

--- a/src/components/dashboard/onboarding-checklist.tsx
+++ b/src/components/dashboard/onboarding-checklist.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { CheckCircle2 } from "lucide-react";
+import type { Job, UserOnboardingFlags } from "@/app/types";
+import { JobStatus } from "@/app/types";
+import { patchUser } from "@/app/services/services";
+
+type Step = {
+  label: string;
+  done: boolean;
+  href: string;
+};
+
+export function OnboardingChecklist({
+  jobs,
+  userFlags,
+}: {
+  jobs: Job[];
+  userFlags: UserOnboardingFlags;
+}) {
+  const [dismissed, setDismissed] = useState(false);
+
+  const step1Done = jobs.length > 0;
+  const step2Done = jobs.some((j) => j.status !== JobStatus.SAVED);
+  const step3Done = userFlags.onboardingPipelineExplored;
+  const step4Done = userFlags.onboardingReportViewed;
+  const allDone = step1Done && step2Done && step3Done && step4Done;
+
+  const steps: Step[] = [
+    {
+      label: "Lägg till ditt första jobb",
+      done: step1Done,
+      href: "/jobb/new",
+    },
+    {
+      label: "Uppdatera ett jobbs status",
+      done: step2Done,
+      href: jobs.length > 0 ? `/jobb/${jobs[0].id}` : "/jobb/new",
+    },
+    {
+      label: "Utforska din pipeline",
+      done: step3Done,
+      href: "/",
+    },
+    {
+      label: "Skapa en aktivitetsrapport",
+      done: step4Done,
+      href: "/aktivitetsrapport",
+    },
+  ];
+
+  const completedCount = steps.filter((s) => s.done).length;
+
+  async function handleDismiss() {
+    setDismissed(true);
+    try {
+      await patchUser({ onboardingDismissed: true });
+    } catch {
+      setDismissed(false);
+    }
+  }
+
+  if (dismissed || userFlags.onboardingDismissed || allDone) {
+    return null;
+  }
+
+  return (
+    <article className="mt-4 rounded-2xl border border-app-stroke bg-app-card p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-xl font-display">Kom igång</h3>
+        <button
+          onClick={handleDismiss}
+          className="text-sm text-app-muted transition hover:text-app-ink"
+        >
+          Dölj
+        </button>
+      </div>
+      <p className="mb-3 text-sm text-app-muted">
+        {completedCount} av {steps.length} klart
+      </p>
+      <div className="divide-y divide-app-stroke">
+        {steps.map((step) =>
+          step.done ? (
+            <div
+              key={step.label}
+              className="flex items-center gap-3 py-3 first:pt-0 last:pb-0"
+            >
+              <CheckCircle2 className="size-5 shrink-0 text-green-500" />
+              <span className="text-base text-app-muted line-through">{step.label}</span>
+            </div>
+          ) : (
+            <Link
+              key={step.label}
+              href={step.href}
+              className="flex items-center gap-3 py-3 first:pt-0 last:pb-0 hover:text-app-primary transition"
+            >
+              <div className="size-5 shrink-0 rounded-full border-2 border-app-stroke" />
+              <span className="text-base text-app-ink">{step.label}</span>
+              <span className="ml-auto text-sm text-app-primary" aria-hidden="true">→</span>
+            </Link>
+          )
+        )}
+      </div>
+    </article>
+  );
+}

--- a/src/components/dashboard/pipeline.tsx
+++ b/src/components/dashboard/pipeline.tsx
@@ -13,7 +13,8 @@ const todoStateLabels: Record<TodoItem["state"], string> = {
 };
 
 const todoStateClassNames: Record<TodoItem["state"], string> = {
-  overdue: "bg-app-blush text-app-red-strong dark:bg-[#3d2823] dark:text-[#ff9395]",
+  overdue:
+    "bg-app-blush text-app-red-strong dark:bg-[#3d2823] dark:text-[#ff9395]",
   today: "bg-app-sand text-[#7a4b00] dark:bg-[#3a2a0f] dark:text-[#ffd38a]",
   soon: "bg-app-cyan text-app-cyan-strong dark:bg-[#123348] dark:text-[#8edcff]",
   upcoming: "bg-blue-100 text-[#295a99] dark:bg-[#123348] dark:text-[#9bc2ff]",
@@ -39,7 +40,7 @@ const jobStatusLabels: Record<JobStatus, string> = {
 export default function Pipeline({ jobs }: Readonly<{ jobs: Job[] }>) {
   if (jobs.length === 0) {
     return (
-      <section className="app-page-content w-full">
+      <section className="app-page-content w-full py-6">
         <article className="overflow-hidden">
           <div className="app-page-content-compact">
             <div>
@@ -47,12 +48,11 @@ export default function Pipeline({ jobs }: Readonly<{ jobs: Job[] }>) {
                 Din nästa möjlighet börjar här.
               </h2>
               <p className="mt-3 text-base text-app-muted sm:text-lg">
-                När du sparar dina jobb här får du en tydlig översikt, statistik och nästa steg samlat på ett ställe. Detta ger dig ett avsevärt mycket enklare workflow i ditt arbetssökande och när det är dags att aktivitetsrapportera till Arbetsförmedlingen.
+                När du sparar dina jobb här får du en tydlig översikt, statistik
+                och nästa steg samlat på ett ställe. Detta ger dig ett avsevärt
+                mycket enklare workflow i ditt arbetssökande och när det är dags
+                att aktivitetsrapportera till Arbetsförmedlingen.
               </p>
-            </div>
-
-            <div className="py-20">
-              <QuickImportInput />
             </div>
           </div>
         </article>

--- a/src/components/landing/landing-page.tsx
+++ b/src/components/landing/landing-page.tsx
@@ -25,6 +25,7 @@ const featureCards = [
       "Samla jobb i en vy som visar vad som krävs härnäst. Tydligt och enkelt att följa upp utan att behöva hålla reda på egna anteckningar eller kalkylark.",
     cardClassName: "bg-app-sky text-app-ink",
     iconClassName: "bg-white/75 text-app-primary",
+    headingClassName: "text-app-primary",
   },
   {
     icon: BarChart3,
@@ -33,6 +34,7 @@ const featureCards = [
       "Få en snabb bild av dina ansökningar, intervjuer och erbjudanden utan kalkylark eller manuell summering.",
     cardClassName: "bg-app-sand text-app-ink md:translate-y-8",
     iconClassName: "bg-white/75 text-app-sand-strong",
+    headingClassName: "text-app-sand-strong",
   },
   {
     icon: Puzzle,
@@ -41,6 +43,7 @@ const featureCards = [
       "Importera jobbannonserna direkt från Platsbanken. Aktivitetsrapportera med bara ett klick när du loggar in på Arbetsförmedlingen.",
     cardClassName: "bg-app-green text-app-ink",
     iconClassName: "bg-white/75 text-app-green-strong",
+    headingClassName: "text-app-green-strong",
   },
 ] as const;
 
@@ -329,7 +332,7 @@ export function LandingPage({ heroHighlights, signedIn }: Readonly<LandingPagePr
                       <div className={`inline-flex size-12 items-center justify-center rounded-2xl ${feature.iconClassName}`}>
                         <Icon className="size-5" strokeWidth={2.2} />
                       </div>
-                      <h3 className="mt-5 font-display text-2xl leading-tight text-app-ink">
+                      <h3 className={`mt-5 font-display text-2xl leading-tight ${feature.headingClassName}`}>
                         {feature.title}
                       </h3>
                       <p className="mt-3 text-base leading-7 text-app-muted text-pretty">
@@ -339,7 +342,7 @@ export function LandingPage({ heroHighlights, signedIn }: Readonly<LandingPagePr
 
                     {feature.title === "Webbläsartillägg i vardagen" ? (
                       <div className="mt-6">
-                        <Link href="/extension" className="inline-flex items-center gap-2 text-sm font-semibold text-app-ink transition hover:text-app-primary">
+                        <Link href="/extension" className="inline-flex items-center gap-2 text-sm font-semibold text-app-muted transition hover:text-app-primary">
                           Läs mer om extension
                           <ArrowRight className="size-4" strokeWidth={2.2} />
                         </Link>

--- a/src/components/report/report-viewed-tracker.tsx
+++ b/src/components/report/report-viewed-tracker.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { patchUser } from "@/app/services/services";
+
+export function ReportViewedTracker({
+  alreadyTracked,
+}: {
+  alreadyTracked: boolean;
+}) {
+  const hasFired = useRef(false);
+
+  useEffect(() => {
+    if (!alreadyTracked && !hasFired.current) {
+      hasFired.current = true;
+      patchUser({ onboardingReportViewed: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return null;
+}

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -1,5 +1,5 @@
 import prisma from "@/lib/prisma";
-import type { Job } from "@/app/types";
+import type { Job, UserOnboardingFlags } from "@/app/types";
 import { JobStatus } from "@/app/types";
 import { auth } from "@clerk/nextjs/server";
 
@@ -112,4 +112,20 @@ export async function getLandingJobsServer(): Promise<Job[]> {
   });
 
   return jobs.map((job) => toAppJob(job));
+}
+
+export async function getUserOnboardingFlags(): Promise<UserOnboardingFlags | null> {
+  const { userId } = await auth();
+  if (!userId) return null;
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      onboardingDismissed: true,
+      onboardingPipelineExplored: true,
+      onboardingReportViewed: true,
+    },
+  });
+
+  return user ?? null;
 }


### PR DESCRIPTION
- `/` is now a public landing page; `/dashboard` is the authenticated app entry with onboarding flags
- Auth redirect target is driven by `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` so one env change routes the whole app
- Onboarding checklist completion card and feature card heading colors polished to match the Jobi.sh color system
