### PR TITLE
fix: back buttons go to previous page (or dashboard) and fix Arabic toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ CLAUDE.md
 /docs/superpowers/specs
 /docs/superpowers/plans
 /GEMINI.md
+/temp

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -185,6 +185,9 @@
     "changeSuccess": "تم تغيير الحالة إلى {status}.",
     "changeError": "تعذّر تحديث الوظيفة الآن."
   },
+  "common": {
+    "back": "رجوع"
+  },
   "confirm": {
     "cancel": "إلغاء",
     "defaultConfirm": "تأكيد",

--- a/messages/en.json
+++ b/messages/en.json
@@ -185,6 +185,9 @@
     "changeSuccess": "Status changed to {status}.",
     "changeError": "The job could not be updated right now."
   },
+  "common": {
+    "back": "Back"
+  },
   "confirm": {
     "cancel": "Cancel",
     "defaultConfirm": "Confirm",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -185,6 +185,9 @@
     "changeSuccess": "Status ändrad till {status}.",
     "changeError": "Jobbet kunde inte uppdateras just nu."
   },
+  "common": {
+    "back": "Tillbaka"
+  },
   "confirm": {
     "cancel": "Avbryt",
     "defaultConfirm": "Bekräfta",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -185,6 +185,9 @@
     "changeSuccess": "Статус змінено на {status}.",
     "changeError": "Наразі не вдалося оновити роботу."
   },
+  "common": {
+    "back": "Назад"
+  },
   "confirm": {
     "cancel": "Скасувати",
     "defaultConfirm": "Підтвердити",

--- a/src/app/jobs/[jobId]/page.tsx
+++ b/src/app/jobs/[jobId]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { BackButton } from "@/components/ui/back-button";
 import { Btn } from "@/components/ui/btn";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Loader } from "@/components/ui/loader";
@@ -33,7 +34,7 @@ export default function JobDetailPage({
       onSuccess: () => {
         toast.success(t("deleteSuccess"));
         setConfirmOpen(false);
-        router.push("/");
+        router.push("/dashboard");
       },
       onError: (error) => {
         toast.error(
@@ -64,9 +65,7 @@ export default function JobDetailPage({
           <p className="text-base text-app-muted sm:text-lg">
             {t("notFound")}
           </p>
-          <Btn href="/" variant="secondary">
-            {t("back")}
-          </Btn>
+          <BackButton label={t("back")} />
         </section>
       </main>
     );
@@ -195,9 +194,7 @@ export default function JobDetailPage({
           <StatusSelect jobId={job.id} initialStatus={job.status} />
         </div>
         <div className="flex w-full gap-4">
-          <Btn variant="secondary" className="w-1/2" href="/">
-            {t("back")}
-          </Btn>
+          <BackButton className="w-1/2" label={t("back")} />
           <Btn
             type="button"
             variant="red"

--- a/src/app/jobs/new/page.tsx
+++ b/src/app/jobs/new/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCreateJob } from "@/lib/hooks/jobs";
 import { trackEvent } from "@/lib/analytics";
+import { BackButton } from "@/components/ui/back-button";
 import { Btn } from "@/components/ui/btn";
 import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
@@ -563,9 +564,7 @@ export default function NewJobPage() {
               </label>
 
                 <div className="flex gap-4">
-                  <Btn href="/" variant="secondary" className="w-1/2">
-                    {t("cancelBtn")}
-                  </Btn>
+                  <BackButton className="w-1/2" label={t("cancelBtn")} />
                   <Btn disabled={createJob.isPending} type="submit" className="w-full" icon={Plus}>
                     {createJob.isPending ? t("saving") : t("addBtn")}
                   </Btn>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { getLocale, getMessages } from "next-intl/server";
 import Script from "next/script";
 import "./globals.css";
 import { AppNavigationShell } from "@/components/navigation/bottom-nav";
+import { NavigationTracker } from "@/components/navigation/navigation-tracker";
 import { PostHogProvider } from "@/components/providers/posthog-provider";
 import { QueryProvider } from "@/components/providers/query-provider";
 import { ThemeProvider } from "@/components/providers/theme-provider";
@@ -111,6 +112,7 @@ export default async function RootLayout({
                 <QueryProvider>
                   <ThemeProvider>
                     <RegisterServiceWorker />
+                    <NavigationTracker />
                     <AppNavigationShell>{children}</AppNavigationShell>
                     <Toaster />
                     <CookieNotice />

--- a/src/components/account/push-notification-card.tsx
+++ b/src/components/account/push-notification-card.tsx
@@ -59,7 +59,9 @@ function NotificationToggleCard({
         <span
           className={cn(
             "inline-block size-5 rounded-full bg-white transition",
-            checked ? "translate-x-6" : "translate-x-1",
+            checked
+              ? "translate-x-6 rtl:-translate-x-6"
+              : "translate-x-1 rtl:-translate-x-1",
           )}
         />
       </span>

--- a/src/components/account/push-notification-card.tsx
+++ b/src/components/account/push-notification-card.tsx
@@ -52,16 +52,14 @@ function NotificationToggleCard({
       </div>
       <span
         className={cn(
-          "relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition",
+          "relative inline-block h-7 w-12 shrink-0 rounded-full transition",
           checked ? "bg-app-primary" : "bg-app-stroke",
         )}
       >
         <span
           className={cn(
-            "inline-block size-5 rounded-full bg-white transition",
-            checked
-              ? "translate-x-6 rtl:-translate-x-6"
-              : "translate-x-1 rtl:-translate-x-1",
+            "absolute top-1 size-5 rounded-full bg-white transition-all",
+            checked ? "start-6" : "start-1",
           )}
         />
       </span>

--- a/src/components/navigation/navigation-tracker.tsx
+++ b/src/components/navigation/navigation-tracker.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+export const IN_APP_NAV_KEY = "jobish:hasInAppNav";
+
+export function NavigationTracker() {
+  const pathname = usePathname();
+  const isInitialMount = useRef(true);
+
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+    try {
+      window.sessionStorage.setItem(IN_APP_NAV_KEY, "1");
+    } catch {
+      // sessionStorage unavailable (private mode, SSR bridging) — safe to ignore
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/report/applied-jobs-page-client.tsx
+++ b/src/components/report/applied-jobs-page-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReportJobEntry } from "@/app/report/report-page-data";
-import { Btn } from "@/components/ui/btn";
+import { BackButton } from "@/components/ui/back-button";
 import Link from "next/link";
 
 type AppliedJobsPageClientProps = {
@@ -17,9 +17,7 @@ export function AppliedJobsPageClient({ jobs }: Readonly<AppliedJobsPageClientPr
           <p className="text-lg text-app-muted">
             Det finns inga registrerade ansökningar att visa ännu.
           </p>
-          <Btn href="/dashboard" variant="secondary" track="back_click">
-            Tillbaka
-          </Btn>
+          <BackButton track="back_click" />
         </section>
       </main>
     );

--- a/src/components/report/report-page-client.tsx
+++ b/src/components/report/report-page-client.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import type { ReportJobEntry, ReportOption } from "@/app/report/report-page-data";
+import { BackButton } from "@/components/ui/back-button";
 import { Btn } from "@/components/ui/btn";
 import {
   Drawer,
@@ -270,9 +271,7 @@ export function ReportPageClient({ jobs, options }: Readonly<ReportPageClientPro
           <p className="text-lg text-app-muted">
             {t("empty")}
           </p>
-          <Btn href="/" variant="secondary">
-            {t("back")}
-          </Btn>
+          <BackButton label={t("back")} />
         </section>
       </main>
     );

--- a/src/components/ui/back-button.tsx
+++ b/src/components/ui/back-button.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { Btn } from "@/components/ui/btn";
+import { trackButtonEvent, type TrackableEvent } from "@/lib/analytics";
+
+type BackButtonProps = {
+  fallbackHref?: string;
+  label?: string;
+  className?: string;
+  track?: TrackableEvent;
+  fullWidth?: boolean;
+};
+
+export function BackButton({
+  fallbackHref = "/dashboard",
+  label,
+  className,
+  track,
+  fullWidth,
+}: Readonly<BackButtonProps>) {
+  const router = useRouter();
+  const t = useTranslations("common");
+
+  function handleClick() {
+    if (track) trackButtonEvent(track);
+
+    const sameOriginReferrer =
+      typeof window !== "undefined" &&
+      document.referrer !== "" &&
+      new URL(document.referrer, window.location.href).origin === window.location.origin;
+
+    if (sameOriginReferrer && window.history.length > 1) {
+      router.back();
+    } else {
+      router.push(fallbackHref);
+    }
+  }
+
+  return (
+    <Btn
+      type="button"
+      variant="secondary"
+      onClick={handleClick}
+      className={className}
+      fullWidth={fullWidth}
+    >
+      {label ?? t("back")}
+    </Btn>
+  );
+}

--- a/src/components/ui/back-button.tsx
+++ b/src/components/ui/back-button.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { Btn } from "@/components/ui/btn";
+import { IN_APP_NAV_KEY } from "@/components/navigation/navigation-tracker";
 import { trackButtonEvent, type TrackableEvent } from "@/lib/analytics";
 
 type BackButtonProps = {
@@ -26,12 +27,17 @@ export function BackButton({
   function handleClick() {
     if (track) trackButtonEvent(track);
 
-    const sameOriginReferrer =
+    const hasInAppNav =
       typeof window !== "undefined" &&
-      document.referrer !== "" &&
-      new URL(document.referrer, window.location.href).origin === window.location.origin;
+      (() => {
+        try {
+          return window.sessionStorage.getItem(IN_APP_NAV_KEY) === "1";
+        } catch {
+          return false;
+        }
+      })();
 
-    if (sameOriginReferrer && window.history.length > 1) {
+    if (hasInAppNav) {
       router.back();
     } else {
       router.push(fallbackHref);


### PR DESCRIPTION
## Summary
- Add reusable `BackButton` component that calls `router.back()` when any in-app navigation has occurred, falling back to `/dashboard` on deep-link entries. Replaces per-page `Btn href=\"/\"` buttons that incorrectly landed on the landing page.
- Add `common.back` translations across `en`, `sv`, `uk`, `ar`.
- Fix push-notification toggle in Arabic — knob now uses logical positioning (`inset-inline-start`) so it slides left in RTL and right in LTR.
- Add `NavigationTracker` mounted in the root layout to flag in-app navigation in `sessionStorage`; BackButton reads the flag to decide between `router.back()` and the dashboard fallback.

## Test plan
- [ ] `/jobs/[id]` → back → returns to the previous in-app page (or `/dashboard` if deep-linked).
- [ ] `/jobs` → `/jobs/[id]` → back → lands on `/jobs`.
- [ ] `/jobs/new` cancel → returns to previous page.
- [ ] Activity report empty-state back → returns to previous page.
- [ ] Switch locale to Arabic → `/account` → notification toggle knob slides correctly (off = right, on = left).
- [ ] Switch locales (en, sv, uk, ar) → back button label translates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)