### PR TITLE
feat: lazy-promote Clerk-migrated users via externalId

### DIFF
--- a/prisma/migrations/20260420000000_add_user_external_id/migration.sql
+++ b/prisma/migrations/20260420000000_add_user_external_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "externalId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_externalId_key" ON "User"("externalId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ enum JobStatus {
 
 model User {
   id              String    @id @default(uuid())
+  externalId      String?   @unique
   email           String    @unique
   name            String    @default("")
   role            UserRole  @default(user)
@@ -71,7 +72,7 @@ model Job {
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt
 
-  user          User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user          User           @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   contactPerson ContactPerson?
   timeline      TimelineItem[]
   tasks         Task[]
@@ -109,7 +110,7 @@ model Task {
   updatedAt   DateTime  @updatedAt
 
   job  Job  @relation(fields: [jobId], references: [id], onDelete: Cascade)
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 }
 
 model PushSubscription {
@@ -121,7 +122,7 @@ model PushSubscription {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   @@index([userId])
 }
@@ -132,7 +133,7 @@ model TodoPushNotification {
   todoId    String
   createdAt DateTime @default(now())
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   @@unique([userId, todoId])
   @@index([userId])

--- a/src/app/api/jobs/[jobId]/route.ts
+++ b/src/app/api/jobs/[jobId]/route.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/nextjs";
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
+import { ensurePromotedUser } from "@/lib/auth/ensurePromotedUser";
 import type { ContactPerson as PrismaContactPerson, Job as PrismaJobModel, Prisma, TimelineItem as PrismaTimelineItem } from "@/app/generated/prisma/client";
 import type { Job, UpdateJobInput } from "@/app/types";
 import { JobStatus } from "@/app/types";
@@ -201,6 +202,8 @@ export async function GET(
     return NextResponse.json({ error: "Kunde inte identifiera användaren." }, { status: 401 });
   }
 
+  await ensurePromotedUser();
+
   let job;
   try {
     job = await prisma.job.findFirst({
@@ -230,6 +233,8 @@ export async function PATCH(
   if (!userId) {
     return NextResponse.json({ error: "Kunde inte identifiera användaren." }, { status: 401 });
   }
+
+  await ensurePromotedUser();
 
   const updates = (await request.json()) as UpdateJobInput;
   const nextArchivedAt = hasDefinedValue(updates.archivedAt)
@@ -294,6 +299,8 @@ export async function DELETE(
   if (!userId) {
     return NextResponse.json({ error: "Kunde inte identifiera användaren." }, { status: 401 });
   }
+
+  await ensurePromotedUser();
 
   let existing;
   try {

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/nextjs";
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
+import { ensurePromotedUser } from "@/lib/auth/ensurePromotedUser";
 import { getPostHogServer } from "@/lib/posthog-server";
 import type { CreateJobInput, Job } from "@/app/types";
 import { JobStatus } from "@/app/types";
@@ -35,6 +36,8 @@ export async function GET(request: NextRequest): Promise<NextResponse<JobsRespon
   if (!userId) {
     return NextResponse.json({ error: "Kunde inte identifiera användaren." }, { status: 401 });
   }
+
+  await ensurePromotedUser();
 
   const includeArchived = request.nextUrl.searchParams.get("includeArchived") === "true";
 
@@ -78,6 +81,8 @@ export async function POST(req: NextRequest): Promise<NextResponse<Job | { error
   if (!userId) {
     return NextResponse.json({ error: "Kunde inte identifiera användaren." }, { status: 401 });
   }
+
+  await ensurePromotedUser();
 
   const payload = (await req.json()) as CreateJobInput;
 

--- a/src/app/api/notifications/push-subscription/route.ts
+++ b/src/app/api/notifications/push-subscription/route.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/app/types";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
+import { ensurePromotedUser } from "@/lib/auth/ensurePromotedUser";
 import {
   deletePushSubscription,
   getPushNotificationSettings,
@@ -21,6 +22,8 @@ type PushSubscriptionDeleteInput = {
 };
 
 async function requireExistingUser(userId: string): Promise<boolean> {
+  await ensurePromotedUser();
+
   const user = await prisma.user.findUnique({
     where: { id: userId },
     select: { id: true },

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -2,6 +2,7 @@ import { ColorScheme, UserRole } from "@/app/generated/prisma/enums";
 import { TERMS_VERSION } from "@/lib/legal";
 import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
+import { ensurePromotedUser } from "@/lib/auth/ensurePromotedUser";
 import * as Sentry from "@sentry/nextjs";
 import { currentUser } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
@@ -42,6 +43,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   if (!clerkUser) {
     return NextResponse.json({ error: "Inte autentiserad." }, { status: 401 });
   }
+
+  await ensurePromotedUser();
 
   const email = clerkUser.emailAddresses[0]?.emailAddress;
 
@@ -90,6 +93,8 @@ export async function POST(
     return NextResponse.json({ error: "Inte autentiserad." }, { status: 401 });
   }
 
+  await ensurePromotedUser();
+
   const email = clerkUser.emailAddresses[0]?.emailAddress;
 
   if (!email) {
@@ -132,6 +137,7 @@ export async function POST(
       where: { email },
       create: {
         id: clerkUser.id,
+        externalId: clerkUser.externalId ?? null,
         email,
         name,
         profession,
@@ -178,6 +184,8 @@ export async function PATCH(
   if (!clerkUser) {
     return NextResponse.json({ error: "Inte autentiserad." }, { status: 401 });
   }
+
+  await ensurePromotedUser();
 
   // id is always the Clerk user ID — POST /api/user sets it explicitly on create
   const body = (await req.json()) as PatchUserInput;

--- a/src/lib/auth/ensurePromotedUser.ts
+++ b/src/lib/auth/ensurePromotedUser.ts
@@ -1,0 +1,37 @@
+import { auth, currentUser } from "@clerk/nextjs/server";
+import prisma from "@/lib/prisma";
+
+// Lazily promotes a Clerk-dev user to their new Clerk-prod id on first authed
+// request. Idempotent: after promotion the fast path is a single indexed lookup.
+// Returns the Clerk user id for the caller's convenience, or null if unauthed.
+export async function ensurePromotedUser(): Promise<string | null> {
+  const { userId } = await auth();
+  if (!userId) return null;
+
+  const clerkUser = await currentUser();
+  const externalId = clerkUser?.externalId ?? null;
+  if (!externalId) return userId;
+
+  const current = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true },
+  });
+  if (current) return userId;
+
+  const legacy = await prisma.user.findUnique({
+    where: { id: externalId },
+    select: { id: true },
+  });
+  if (!legacy) return userId;
+
+  try {
+    await prisma.user.update({
+      where: { id: externalId },
+      data: { id: userId, externalId },
+    });
+  } catch (err) {
+    // A concurrent request promoted the same row; P2025 = record not found.
+    if (!(err instanceof Error && err.message.includes("P2025"))) throw err;
+  }
+  return userId;
+}

--- a/src/lib/auth/requireAdmin.ts
+++ b/src/lib/auth/requireAdmin.ts
@@ -2,10 +2,13 @@ import { auth } from "@clerk/nextjs/server";
 import { notFound } from "next/navigation";
 import prisma from "@/lib/prisma";
 import { UserRole } from "@/app/generated/prisma/enums";
+import { ensurePromotedUser } from "@/lib/auth/ensurePromotedUser";
 
 export async function requireAdmin() {
   const { userId } = await auth();
   if (!userId) notFound();
+
+  await ensurePromotedUser();
 
   const user = await prisma.user.findUnique({ where: { id: userId } });
   if (!user || user.role !== UserRole.admin) notFound();

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -2,6 +2,7 @@ import prisma from "@/lib/prisma";
 import type { Job, UserOnboardingFlags } from "@/app/types";
 import { JobStatus } from "@/app/types";
 import { auth } from "@clerk/nextjs/server";
+import { ensurePromotedUser } from "@/lib/auth/ensurePromotedUser";
 
 const prismaStatusToAppStatus: Record<string, JobStatus> = {
   saved: JobStatus.SAVED,
@@ -66,6 +67,8 @@ export async function getJobsServer(options: GetJobsServerOptions = {}): Promise
   const { userId } = await auth();
   if (!userId) return [];
 
+  await ensurePromotedUser();
+
   const jobs = await prisma.job.findMany({
     where: {
       userId,
@@ -117,6 +120,8 @@ export async function getLandingJobsServer(): Promise<Job[]> {
 export async function getUserOnboardingFlags(): Promise<UserOnboardingFlags | null> {
   const { userId } = await auth();
   if (!userId) return null;
+
+  await ensurePromotedUser();
 
   const user = await prisma.user.findUnique({
     where: { id: userId },


### PR DESCRIPTION
## Summary
- Add `User.externalId` (unique, nullable) to Prisma schema; make `onUpdate: Cascade` explicit on the four `User` relations
- New `ensurePromotedUser` helper — on first authed request from a Clerk-migrated user, rewrites `User.id` from the old dev id to the new prod id and lets Postgres cascade the change to `Job`, `Task`, `PushSubscription`, `TodoPushNotification`
- Wire the promoter into every authed Prisma entry point (`/api/user`, `/api/jobs`, `/api/jobs/[jobId]`, `/api/notifications/push-subscription`, `requireAdmin`, `server/queries.ts`)
- Capture `externalId` in the `POST /api/user` create-profile upsert

## Context
Clerk prod assigned new `user_id`s during the dev→prod migration and preserved the old dev ids in `external_id`. Our Prisma rows still key on the old dev ids via `User.id`, so once requests arrive with the new prod ids, user-scoped queries return empty. This patch reconciles lazily on first login.

## Migration note
The repo's shadow DB is currently broken by a pre-existing migration ordering issue (`20260410013304_push_migration` runs before `PushSubscription` is created), so this migration was written by hand and applied with `prisma migrate deploy`. Worth fixing the shadow DB separately.

## Test plan
- [ ] Deploy to an environment with live Clerk keys and run the migration
- [ ] Sign in as a real migrated user; verify the pipeline renders their existing jobs
- [ ] Inspect Postgres: confirm their `User.id` now equals the prod Clerk id, `User.externalId` equals the old dev id, and every `Job.userId` cascaded
- [ ] Sign in again — promoter fast path should short-circuit (no UPDATE)
- [ ] Register a fresh prod user; confirm `User.externalId` is null and create-profile flow is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)